### PR TITLE
Add test suite

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,0 +1,49 @@
+module.exports = function(config) {
+  var testWebpackConfig = require('./webpack.test.js')();
+
+  var configuration = {
+
+    // base path that will be used to resolve all patterns (e.g. files, exclude)
+    basePath: '',
+
+    frameworks: ['jasmine'],
+    exclude: [ ],
+
+    files: [
+       { pattern: 'test/spec-bundle.js', watched: false }
+    ],
+
+    preprocessors: {
+       'test/spec-bundle.js': ['webpack']
+    },
+
+    // webpack setup
+    webpack: testWebpackConfig,
+    webpackMiddleware: {stats: 'errors-only'},
+
+    reporters: [ 'mocha' ],
+
+    autoWatch: false,
+
+    browsers: [
+      // 'Chrome',
+      'ChromeHeadless',
+    ],
+
+    customLaunchers: {
+       ChromeHeadless: {
+          base: 'Chrome',
+          flags: [
+             '--no-sandbox',
+             '--headless',
+             '--disable-gpu',
+             '--remote-debugging-port=9222',
+          ],
+       }
+     },
+
+     singleRun: true
+  };
+
+  config.set(configuration);
+};

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "prepublish": "npm run build",
     "build": "rimraf dist && tsc --pretty",
-    "test": "karma start",
+    "test": "npm run build && karma start",
     "watch": "rimraf dist && tsc --watch --pretty",
     "watch:test": "npm run test -- --auto-watch --no-single-run"
   },

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "prepublish": "npm run build",
     "build": "rimraf dist && tsc --pretty",
-    "watch": "rimraf dist && tsc --watch --pretty"
+    "test": "karma start",
+    "watch": "rimraf dist && tsc --watch --pretty",
+    "watch:test": "npm run test -- --auto-watch --no-single-run"
   },
   "repository": {
     "type": "git",
@@ -23,8 +25,18 @@
   "homepage": "https://github.com/goloveychuk/tsruntime",
   "license": "MIT",
   "devDependencies": {
+    "@types/jasmine": "^2.2.34",
+    "awesome-typescript-loader": "3.1.3",
+    "jasmine": "~2.5.2",
+    "karma": "~1.5.0",
+    "karma-chrome-launcher": "^2.0.0",
+    "karma-jasmine": "~1.1.0",
+    "karma-mocha-reporter": "~2.2.3",
+    "karma-sourcemap-loader": "~0.3.7",
+    "karma-webpack": "~2.0.3",
     "reflect-metadata": "^0.1.10",
     "rimraf": "^2.6.1",
-    "typescript": "^2.3.0"
+    "typescript": "^2.3.2",
+    "webpack": "2.2.0"
   }
 }

--- a/test/class_decoration.spec.ts
+++ b/test/class_decoration.spec.ts
@@ -1,0 +1,26 @@
+import {
+   Reflective,
+   Types,
+   getType
+} from '../src';
+
+const TypeKind = Types.TypeKind;
+
+
+@Reflective
+class TestClass {
+    propA: string | null = '';
+}
+
+describe('Class Decoration', () => {
+
+   it('should decorate null properties', () => {
+      const ptype = getType(TestClass.prototype, 'propA') as Types.UnionType;
+
+      expect(ptype.kind).toEqual(TypeKind.Union)
+      expect(ptype.types[0].kind).toEqual(TypeKind.String);
+      expect(ptype.types[1].kind).toEqual(TypeKind.Null);
+   });
+
+});
+

--- a/test/custom_decorator.spec.ts
+++ b/test/custom_decorator.spec.ts
@@ -1,0 +1,34 @@
+import {
+   getType,
+} from '../src';
+
+
+function UserDecorator(target: any) { }
+
+function OtherDecorator(target: any) { }
+
+@UserDecorator
+export class MyClassA {
+    a: string;
+}
+
+@OtherDecorator
+export class MyClassB {
+    a: string;
+}
+
+describe('Custom Decorators', () => {
+   // Note UserDecorator is configured in webpack.test.js
+   it('should allow UserDecorator', () => {
+      const clsType = getType(MyClassA);
+      expect(clsType).not.toBeNull();
+   });
+
+   it('should throw on non-decorated', () => {
+      expect(() => {
+          getType(MyClassB);
+      }).toThrow();
+   });
+
+});
+

--- a/test/example.spec.ts
+++ b/test/example.spec.ts
@@ -1,0 +1,46 @@
+import {
+   Reflective,
+   Types,
+   getType,
+} from '../src';
+
+const TypeKind = Types.TypeKind;
+
+/**
+ * Example from README.md file.
+ */
+
+@Reflective
+export class StatsModel {
+    a?: number
+    b: string
+    c: Array<string>
+    d: number | string | null
+}
+
+@Reflective
+class Foo extends Array<string> {
+
+}
+
+describe('Example works', () => {
+   it('should have class types', () => {
+      const clsType = getType(Foo) as Types.ClassType;
+      const baseType = clsType.extends;
+      expect(clsType).not.toBeNull();
+
+      expect(clsType.props).toEqual([]);
+      expect(baseType!.kind).toEqual(TypeKind.Reference);
+   });
+
+   it('should have property type details', () => {
+      const stats_type = getType(StatsModel) as Types.ClassType;
+      expect(stats_type.props).toEqual(['a', 'b', 'c', 'd']);
+
+      const dType = getType(StatsModel.prototype, "d")
+      expect(dType).not.toBeNull();
+      expect(dType.kind).toEqual(TypeKind.Union);
+   });
+
+});
+

--- a/test/jasmine.spec.ts
+++ b/test/jasmine.spec.ts
@@ -1,0 +1,5 @@
+describe('Jasmine works', () => {
+   it('should check', () => {
+      expect(1).toEqual(1);
+   });
+});

--- a/test/spec-bundle.js
+++ b/test/spec-bundle.js
@@ -1,0 +1,5 @@
+// Entrypoint for collecting test files for karma to run
+//   see: https://github.com/webpack-contrib/karma-webpack
+//
+var testContext = require.context('.', true, /\.spec\.ts/);
+testContext.keys().forEach(testContext);

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -1,0 +1,6 @@
+{
+   "extends": "../tsconfig.json",
+   "include": [
+      "*.ts"
+   ]
+}

--- a/webpack.test.js
+++ b/webpack.test.js
@@ -1,0 +1,41 @@
+const tsRuntimeBuilder = require('./dist/transformer').default;
+
+function getCustomTransformers() {
+  return {
+    before: [
+      tsRuntimeBuilder({
+        decoratorNames: ['Reflective', 'UserDecorator']
+      })
+    ]
+  }
+}
+
+
+module.exports = function (options) {
+return {
+   devtool: '#inline-source-map',
+
+   resolve: {
+      extensions: ['.ts', '.js'],
+   },
+
+   module: {
+
+      rules: [
+         // Typescript
+         {
+            test: /\.ts$/,
+            use: [
+               {
+                  loader: 'awesome-typescript-loader',
+                  options: {
+                     getCustomTransformers: getCustomTransformers,
+                  }
+               },
+            ],
+         },
+      ],
+   }
+};
+
+};


### PR DESCRIPTION
This add test suite support.

The suite uses karma as a runner, Jasmine as the test framework, and webpack to build the packages.

There are 2 new commands:

`npm run test` provides a single execution of the test suite.
`npm run watch:test` starts up the test suite in watch mode

The way the test suite works is to pull any .spec.ts files from the test/ directory and to run them through a webpack build that is using the local install of tsruntime in ./dist to transform the test spec files.  This allows for writing tests that define classes to be reflected and then immediately test to see if the reflected information is what was expected.

Note that there is a bit of an issue here were if you change the code in the ./src directory for the transformer, it will not be rebuilt by `watch:test`.  This is because I could not find a way to make webpack do this.  So instead what you need to do is open two terminal windows and in one of them run `npm run watch` and in the other run `npm run watch:test`.  This *should* allow changing any source or spec files and immediately seeing the results.