### PR TITLE
Extend transforms and bug fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "test": "npm run build && karma start",
     "watch": "rimraf dist && tsc --watch --pretty",
     "watch:test": "npm run test -- --auto-watch --no-single-run",
-    "build:test": "rimraf ./tests/build && tsc -p ./tests"
+    "build:test": "rimraf ./tests/build && tsc -p ./tests",
+    "build:test_webpack": "webpack --config webpack.test.js"
   },
   "repository": {
     "type": "git",

--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -200,7 +200,12 @@ function Transformer(context: ts.TransformationContext) {
     }
     for (const dec of node.decorators) {
       if (dec.kind == ts.SyntaxKind.Decorator) {
-        if (transformConfig.decoratorNames.indexOf(dec.expression.getText()) != -1) {
+        // Find decorator name. If decorator is called as function, then name is at first child.
+        const dec_name = (dec.expression.getChildCount() === 0) ?
+                          dec.expression.getText() :
+                          dec.expression.getChildAt(0).getText();
+
+        if (transformConfig.decoratorNames.indexOf(dec_name) != -1) {
           return true
         }
       }

--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -122,7 +122,7 @@ function Transformer(context: ts.TransformationContext) {
         return serializeTuple(<ts.TupleTypeNode>type)
       default:
         showWarning(type, "Unknown type");
-        throw new Error(`unknown type: ${type.kind}`)
+        return { kind: Types.TypeKind.Unknown };
     }
   }
   function serializeGenericType(typeName: ts.Expression, typeArguments?: ts.NodeArray<ts.TypeNode>): Types.Type {

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,19 +17,21 @@ export module Types {
     Undefined,
     Null,
     Never,
-    
+
     Object,
-    
+
     Tuple,
     Union,
     Reference,
-    Class
+    Class,
+
+    Unknown = 999
   }
 
 
 
 
-  export type Type = TupleType | AnyType | VoidType | NeverType | ESSymbolType |  EnumType  | ObjectType | ClassType | StringType | NumberType | BooleanType | ReferenceType | UnionType | NullType | UndefinedType
+  export type Type = TupleType | AnyType | VoidType | NeverType | ESSymbolType |  EnumType  | ObjectType | ClassType | StringType | NumberType | BooleanType | ReferenceType | UnionType | NullType | UndefinedType | UnknownType
 
   export interface BaseType {
     kind: TypeKind
@@ -95,6 +97,10 @@ export module Types {
     kind: TypeKind.Class
     props: string[]
     extends?: Types.Type
+  }
+
+  export interface UnknownType extends BaseType {
+    kind: TypeKind.Unknown
   }
 
 }

--- a/tests/alltypes.spec.ts
+++ b/tests/alltypes.spec.ts
@@ -57,6 +57,11 @@ class DerrivedTypes {
     genRef = new GenericCls<string>()
 }
 
+@Reflective
+class UnionTypes {
+    string_null: string | null = '';
+    string_undefined: string | undefined;
+}
 
 
 // a.a = null
@@ -100,6 +105,20 @@ describe('All types', () => {
    it('symbol', () => {
       const clsType = getPropType(AllTypes, "symbol") as Types.ESSymbolType;
       expect(clsType.kind).toBe(Types.TypeKind.ESSymbol)
+   });
+
+   describe('union types', () => {
+      it('string | null', () => {
+          const type = getPropType(UnionTypes, "string_null") as Types.UnionType;
+          expect(type.types[0].kind).toBe(Types.TypeKind.String);
+          expect(type.types[1].kind).toBe(Types.TypeKind.Null);
+      });
+
+      it('string | undefined', () => {
+          const type = getPropType(UnionTypes, "string_undefined") as Types.UnionType;
+          expect(type.types[0].kind).toBe(Types.TypeKind.String);
+          expect(type.types[1].kind).toBe(Types.TypeKind.Undefined);
+      });
    });
 });
 

--- a/tests/custom_decorator.spec.ts
+++ b/tests/custom_decorator.spec.ts
@@ -12,6 +12,16 @@ function UserDecorator(target: any) {
 
 function OtherDecorator(target: any) { }
 
+export function ParamDecorator(params: {
+                           strParam: string,
+                        }): Function {
+/* tslint:enable:ext-variable-name */
+   return function innerDecorator(ctor: Function): void {
+      // Graft on other metadata information
+      (ctor as any).StrParam = params.strParam;
+   };
+}
+
 @UserDecorator
 export class MyClassA {
     a: string;
@@ -19,6 +29,13 @@ export class MyClassA {
 
 @OtherDecorator
 export class MyClassB {
+    a: string;
+}
+
+@ParamDecorator({
+    strParam: 'string_value',
+})
+export class ParamClass {
     a: string;
 }
 
@@ -33,6 +50,11 @@ describe('Custom Decorators', () => {
       expect(() => {
           mustGetType(MyClassB);
       }).toThrow();
+   });
+
+   it('should allow decorators with params', () => {
+      const clsType = mustGetType(ParamClass);
+      expect((ParamClass as any).StrParam).toEqual('string_value');
    });
 
 });

--- a/tests/custom_decorator.spec.ts
+++ b/tests/custom_decorator.spec.ts
@@ -4,7 +4,11 @@ import {
 } from '../src';
 
 
-function UserDecorator(target: any) { }
+function UserDecorator(target: any) {
+    // Verifies that tsruntime decorations are
+    // available before user decorator is applied.
+    const clsType = mustGetType(target);
+}
 
 function OtherDecorator(target: any) { }
 

--- a/tests/external_classes.ts
+++ b/tests/external_classes.ts
@@ -1,0 +1,3 @@
+export class ExternalClass {
+   a: string = '';
+}

--- a/tests/missing_types.spec.ts
+++ b/tests/missing_types.spec.ts
@@ -42,5 +42,16 @@ describe('Missing Support', () => {
       expect(children_type.arguments[0].kind).toBe(Types.TypeKind.Unknown);
    });
 
+   it('should work nested', () => {
+      @Reflective
+      class InnerClass {
+          a: string;
+      }
+
+      const clsType = getType(InnerClass);
+      // SHOULD WORK
+      //expect(clsType).toBeDefined();
+   });
+
 });
 

--- a/tests/missing_types.spec.ts
+++ b/tests/missing_types.spec.ts
@@ -27,6 +27,25 @@ class ParentClass {
    children: (OuterClass|TestClass)[] = [];
 }
 
+
+interface IGeom {
+    coordinates: any;
+}
+
+/**
+ * Breaks the runtime load.
+ *  reason: tsruntime generates a object that assumes "IGeom" is a class type that can
+ *          be referred to at runtime. Since it is not, the generated code can't
+ *          execute and has a reference error.
+ */
+/*
+@Reflective
+class LocationClass {
+   geomProp:  IGeom;
+}
+*/
+
+
 describe('Missing Support', () => {
    it('should support "type of" types', () => {
       // should allow supporting type of types
@@ -53,5 +72,11 @@ describe('Missing Support', () => {
       //expect(clsType).toBeDefined();
    });
 
-});
+   /*
+   it('Interface / types in properties', () => {
+      const clsType = getType(LocationClass);
+      expect(clsType).toBeDefined();
+   });
+   */
 
+});

--- a/tests/missing_types.spec.ts
+++ b/tests/missing_types.spec.ts
@@ -12,6 +12,8 @@ import {
    Types
 } from '../src/types'
 
+import { ExternalClass } from './external_classes';
+
 class OuterClass {
 
 }
@@ -27,13 +29,26 @@ class ParentClass {
    children: (OuterClass|TestClass)[] = [];
 }
 
+/**
+ * BUG: Breaks the runtime load.
+ *
+ * Refers to a type ("ExternalClass") that is not used in this
+ * file by the normal code so it is not exposed.
+ */
+/*
+@Reflective
+class UseExternalClass {
+   extRef: ExternalClass;
+}
+*/
+
 
 interface IGeom {
     coordinates: any;
 }
 
 /**
- * Breaks the runtime load.
+ * BUG: Breaks the runtime load.
  *  reason: tsruntime generates a object that assumes "IGeom" is a class type that can
  *          be referred to at runtime. Since it is not, the generated code can't
  *          execute and has a reference error.

--- a/tests/missing_types.spec.ts
+++ b/tests/missing_types.spec.ts
@@ -1,0 +1,46 @@
+/**
+ * File with tests showing current limitations.
+ *
+ * note: tests may be need to be disabled until they work correctly.
+ */
+import {
+   Reflective,
+   mustGetType,
+   mustGetPropType,
+   getType,
+   getPropType,
+   Types
+} from '../src/types'
+
+class OuterClass {
+
+}
+
+@Reflective
+class TestClass {
+   type_prop: typeof OuterClass = OuterClass;
+}
+
+
+@Reflective
+class ParentClass {
+   children: (OuterClass|TestClass)[] = [];
+}
+
+describe('Missing Support', () => {
+   it('should support "type of" types', () => {
+      // should allow supporting type of types
+      const type_prop_type = getPropType(TestClass, "type_prop") as Types.UnknownType;
+      expect(type_prop_type.kind).toBe(Types.TypeKind.Unknown);
+   });
+
+   it('should support class union arrays', () => {
+      // Should allow reflection of the types that make up the array
+      const children_type = getPropType(ParentClass, "children") as Types.ReferenceType;
+      expect(children_type.kind).toBe(Types.TypeKind.Reference);
+      expect(children_type.type).toEqual(Array);
+      expect(children_type.arguments[0].kind).toBe(Types.TypeKind.Unknown);
+   });
+
+});
+

--- a/webpack.test.js
+++ b/webpack.test.js
@@ -4,7 +4,7 @@ function getCustomTransformers() {
   return {
     before: [
       tsRuntimeBuilder({
-        decoratorNames: ['Reflective', 'UserDecorator']
+        decoratorNames: ['Reflective', 'UserDecorator', 'ParamDecorator']
       })
     ]
   }
@@ -14,6 +14,13 @@ function getCustomTransformers() {
 module.exports = function (options) {
 return {
    devtool: '#inline-source-map',
+
+   // note: not used by karma, but can be used
+   //   to help debug transform code by running webpack directly
+   entry: './tests/spec-bundle.js',
+   output: {
+     filename: './tests/build/test.bundle.js'
+   },
 
    resolve: {
       extensions: ['.ts', '.js'],


### PR DESCRIPTION
This branch includes some fixes and changes I needed to get tsruntime working on our production code.

  - Added checks for decorator application ordering
  - Fix bug to allow callable decorators to work with tsruntime
  - Added build command to build test suite with webpack  (useful for running transforms in a node debugger like vscode)
  - Add detailed warning information to output for transform failures.  (file, line number, etc)
  - Added an UnknownType.  The idea here is that if tsruntime can't determine the type, we can still use the type information for the code it was able to recognize so it adds an unknown type instead of aborting
  - Add a test for null unions (which worked fine)
  - Added a spec for a few things I found that are not supported.  The idea with the spec file is to provide a way to test/fix by running the test suite and build in a debugger.
  - Add spec showing nested classes not working.

note: Since there are a variety of changes, I suggest reviewing it using the commit by commit view in the files changed view.

@goloveychuk Let me know if you think this is too many things for one pull.  I kind of got on a roll here fixing up things that were causing me issues and just kept them all here.

