### PR TITLE
Update to Typescript v5

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,12 @@ Typescript custom transformer for emitting types for using in runtime (reflectio
 ## Motivation
 Sometimes you need types metadata in the runtime, e.g. to validate backend response or set `propTypes` from `interface Props{}` 
 
-It's docs for v3. For v2 go [here](https://github.com/goloveychuk/tsruntime/blob/596c10ecc31618effc598854bdb12ecd08e6dcc2/README.md)
 
 ## Prerequisites
-- `typescript: =>2.3.0`
+- `typescript: =>5.0.0`
 
 ## Setup
-- install `tsruntime` and `ttypescript`
+- install `tsruntime` and `ts-patch`
 - change `tsconfig.json`:
 ```js
 {
@@ -26,9 +25,9 @@ It's docs for v3. For v2 go [here](https://github.com/goloveychuk/tsruntime/blob
     }
 }
 ```
-- run with `ttypescript` compiler:
-  - `ts-node --compiler=ttypescript src/index.ts`
-  - `ttsc` 
+- run with `ts-patch` compiler:
+  - `ts-node --compiler=ts-patch/compiler src/index.ts`
+  - `tspc` 
   - change `compiler` in `awesome-typescript-loader` config
   - etc
 ### See [Example](./packages/example)

--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
     "reflect-metadata": "^0.1.10",
     "rimraf": "^2.6.1",
     "ts-jest": "^23.10.4",
-    "ttypescript": "1.5.15",
-    "typescript": "4.9.5"
+    "ts-patch": "3.0.2",
+    "typescript": "5.3.2"
   },
   "name": "tsruntime"
 }

--- a/packages/example/package.json
+++ b/packages/example/package.json
@@ -5,12 +5,12 @@
     "authors": "author",
     "version": "3.0.0-beta.1",
     "scripts": {
-        "build": "ttsc",
-        "tsnode": "ts-node --compiler=ttypescript src/index.ts"
+        "build": "tspc",
+        "tsnode": "ts-node --compiler=ts-patch/compiler src/index.ts"
     },
     "main": "pathToMain",
     "devDependencies": {
-        "ts-node": "8.1.0",
-        "ttypescript": "1.5.15"
+        "ts-node": "10.9.1",
+        "ts-patch": "3.0.2"
     }
 }

--- a/packages/example/src/index.ts
+++ b/packages/example/src/index.ts
@@ -4,17 +4,30 @@ import {reflect, Reflective, getClassType} from 'tsruntime'
 
 
 
+interface Address {
+    city?: string
+    street: string
+}
 
 
 
 @Reflective
 class Cls {
-    str!: string
+    public str!: string
+    protected num?: number
+    private names!: Array<string>
+    address!: Address
+    status: 'requirer' | 'city' | 'accept' | 'reject' = 'accept';
+
+    constructor(public foo: string, private bar: number) {
+        console.log(foo, bar)
+    }
 }
 
 
 
-const type = reflect<string>()
+const type = reflect<Cls>()
+const classType = getClassType(Cls);
 
-console.log(getClassType(Cls))
+console.log(classType)
 console.log(type)

--- a/packages/example/tsconfig.json
+++ b/packages/example/tsconfig.json
@@ -8,8 +8,8 @@
         "sourceMap": false,
         "declaration": false,
         "plugins": [
-            { "transform": "tsruntime/transformer.js", "type": "program" },
-        ],
+            { "transform": "tsruntime/transformer.js", "type": "program" }
+        ]
     },
     "include": [
         "src/**/*"

--- a/packages/tests/package.json
+++ b/packages/tests/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "test": "npm run build && jest --no-cache",
-    "build": "rimraf ./dist && ttsc"
+    "build": "rimraf ./dist && tspc"
   },
   "repository": {
     "type": "git",

--- a/packages/tests/src/types/interfaces.test.ts
+++ b/packages/tests/src/types/interfaces.test.ts
@@ -25,7 +25,7 @@ interface IExtends extends IExtended {
 }
 
 
-const stringType = {kind: Types.TypeKind.String}
+const stringType = {kind: Types.TypeKind.String, modifiers: Types.ModifierFlags.None}
 
 
 describe("interfaces", () => {
@@ -42,7 +42,7 @@ describe("interfaces", () => {
             [constKey]: stringType,
             ['computed-string']: stringType,
             [uniqSymb]: stringType,
-            method: {kind: Types.TypeKind.Function}
+            method: {kind: Types.TypeKind.Function, modifiers: Types.ModifierFlags.None}
         }
     });
   });

--- a/packages/tests/src/types/objectTypes.test.ts
+++ b/packages/tests/src/types/objectTypes.test.ts
@@ -6,7 +6,7 @@ const constKey = "some-key";
 const uniqSymb = Symbol("some symb");
 
 
-const stringType = {kind: Types.TypeKind.String}
+const stringType = {kind: Types.TypeKind.String, modifiers: Types.ModifierFlags.None}
 
 type ObjectType = {
     key: string

--- a/packages/tests/src/types/propertyInitializer.test.ts
+++ b/packages/tests/src/types/propertyInitializer.test.ts
@@ -40,17 +40,17 @@ function typeIsEqual(type: Types.ReflectedType, val: any) {
 
 describe("class properties initializers", () => {
   it("primitive types", () => {
-    typeIsEqual(getPropType("string"), { kind: TypeKind.String });
+    typeIsEqual(getPropType("string"), { kind: TypeKind.String, modifiers: Types.ModifierFlags.None });
     initializerIsEqual(getPropType("string"), 'string');
-    typeIsEqual(getPropType("number"), { kind: TypeKind.Number });
+    typeIsEqual(getPropType("number"), { kind: TypeKind.Number, modifiers: Types.ModifierFlags.None  });
     initializerIsEqual(getPropType("number"), 42);
-    typeIsEqual(getPropType("true"), { kind: TypeKind.Boolean });
+    typeIsEqual(getPropType("true"), { kind: TypeKind.Boolean, modifiers: Types.ModifierFlags.None  });
     initializerIsEqual(getPropType("true"), true);
-    typeIsEqual(getPropType("false"), { kind: TypeKind.Boolean });
+    typeIsEqual(getPropType("false"), { kind: TypeKind.Boolean, modifiers: Types.ModifierFlags.None  });
     initializerIsEqual(getPropType("false"), false);
-    typeIsEqual(getPropType("null"), { kind: TypeKind.Null });
+    typeIsEqual(getPropType("null"), { kind: TypeKind.Null, modifiers: Types.ModifierFlags.None  });
     initializerIsEqual(getPropType("null"), null);
-    typeIsEqual(getPropType("undefined"), { kind: TypeKind.Undefined });
+    typeIsEqual(getPropType("undefined"), { kind: TypeKind.Undefined, modifiers: Types.ModifierFlags.None  });
     initializerIsEqual(getPropType("undefined"), undefined);
   });
   it("arrays", () => {
@@ -60,6 +60,7 @@ describe("class properties initializers", () => {
       typeIsEqual(type, {
         kind: TypeKind.Reference,
         type: Array,
+        modifiers: Types.ModifierFlags.None,
         arguments: [{ kind: TypeKind.String }]
       });
       initializerIsEqual(type, ["string"]);
@@ -71,6 +72,7 @@ describe("class properties initializers", () => {
     typeIsEqual(type, {
         kind: TypeKind.Reference,
         type: Cls,
+        modifiers: Types.ModifierFlags.None,
         arguments: []
       });
       expect(type.initializer).not.toBeUndefined()
@@ -82,6 +84,7 @@ describe("class properties initializers", () => {
     typeIsEqual(type, {
         kind: TypeKind.Reference,
         type: GenericCls,
+        modifiers: Types.ModifierFlags.None,
         arguments: [{ kind: Types.TypeKind.String }]
       });
       expect(type.initializer).not.toBeUndefined()

--- a/packages/tests/src/types/transform.test.ts
+++ b/packages/tests/src/types/transform.test.ts
@@ -39,6 +39,7 @@ describe("transform", () => {
         exported: {
           kind: Types.TypeKind.Reference,
           type: ExportedClass,
+          modifiers: Types.ModifierFlags.None,
           arguments: []
         }
       },
@@ -70,7 +71,7 @@ describe("transform", () => {
       name: "TestClass",
       kind: Types.TypeKind.Class,
       properties: {
-        prop: { kind: Types.TypeKind.String }
+        prop: { kind: Types.TypeKind.String, modifiers: Types.ModifierFlags.None }
       },
       constructors: [{modifiers: 0, parameters: []}],
     });

--- a/packages/tsruntime/src/runtime/publicTypes.ts
+++ b/packages/tsruntime/src/runtime/publicTypes.ts
@@ -1,3 +1,7 @@
+import { ModifierFlags } from "typescript";
+
+export { ModifierFlags } from "typescript";
+
 export enum TypeKind {
   Any = 1,
   String,
@@ -25,28 +29,6 @@ export enum TypeKind {
   Function,
 
   Unknown2 = 999
-}
-
-export enum ModifierFlags {
-  None = 0,
-  Export = 1,
-  Ambient = 2,
-  Public = 4,
-  Private = 8,
-  Protected = 16,
-  Static = 32,
-  Readonly = 64,
-  Abstract = 128,
-  Async = 256,
-  Default = 512,
-  Const = 2048,
-  HasComputedFlags = 536870912,
-  AccessibilityModifier = 28,
-  ParameterPropertyModifier = 92,
-  NonPublicAccessibilityModifier = 24,
-  TypeScriptModifier = 2270,
-  ExportDefault = 513,
-  All = 3071
 }
 
 export type StringType = BaseType<TypeKind.String, string>;
@@ -78,7 +60,7 @@ export type SimpleTypes =
   | UnknownType
   | Unknown2Type;
 
-  
+
 
 export type ReflectedType =
   | ObjectType

--- a/packages/tsruntime/src/runtime/publicTypes.ts
+++ b/packages/tsruntime/src/runtime/publicTypes.ts
@@ -75,6 +75,7 @@ export type ReflectedType =
 
 export interface BaseType<TKind extends TypeKind, T> {
   kind: TKind;
+  modifiers?: ModifierFlags;
   initializer?: () => T;
 }
 

--- a/packages/tsruntime/src/transform/makeLiteral.ts
+++ b/packages/tsruntime/src/transform/makeLiteral.ts
@@ -7,9 +7,9 @@ function getExpressionForPropertyName(name: ts.PropertyName) { //copied from typ
     // if (ts.isComputedPropertyName(name)) {
     //   throw new Error('is computed property')
     // }
-  
+
     if (ts.isIdentifier(name)) {
-      return ts.createLiteral(ts.idText(name))
+      return ts.factory.createStringLiteral(ts.idText(name))
     }
     return name
 }
@@ -17,34 +17,41 @@ function getExpressionForPropertyName(name: ts.PropertyName) { //copied from typ
   
 export function makeLiteral(type: ReflectedType): ts.ObjectLiteralExpression {
     const assigns = []
-    const kindAssign = ts.createPropertyAssignment("kind", ts.createLiteral(type.kind))
+    const kindAssign = ts.factory.createPropertyAssignment("kind", ts.factory.createNumericLiteral(type.kind))
     const kindAssignComment = ts.addSyntheticTrailingComment(kindAssign, ts.SyntaxKind.MultiLineCommentTrivia, TypeKind[type.kind], false)
     assigns.push(kindAssignComment)
+
     if (type.initializer !== undefined) {
-      assigns.push(ts.createPropertyAssignment("initializer", type.initializer))
+      assigns.push(ts.factory.createPropertyAssignment("initializer", type.initializer))
     }
 
     switch (type.kind) {
       case TypeKind.Object:
       case TypeKind.Class:
         if (type.name) {
-          assigns.push(ts.createPropertyAssignment("name", ts.createLiteral(type.name)))
+          assigns.push(ts.factory.createPropertyAssignment("name", ts.factory.createStringLiteral(type.name)))
         }
-        // assigns.push(ts.createPropertyAssignment("arguments", ts.createArrayLiteral(type.arguments.map(makeLiteral))))
-        assigns.push(ts.createPropertyAssignment("properties", ts.createObjectLiteral(
-          type.properties.map(({name, type}) =>
-            ts.createPropertyAssignment(getExpressionForPropertyName(name), makeLiteral(type))
-        ))))
+        // assigns.push(ts.factory.createPropertyAssignment("arguments", ts.createArrayLiteral(type.arguments.map(makeLiteral))))
+        assigns.push(
+          ts.factory.createPropertyAssignment(
+            "properties",
+            ts.factory.createObjectLiteralExpression(
+              type.properties.map(({name, type}) =>
+                ts.factory.createPropertyAssignment(getExpressionForPropertyName(name), makeLiteral(type))
+              )
+            )
+          )
+        )
         if (type.kind === TypeKind.Class) {
-          assigns.push(ts.createPropertyAssignment("constructors", ts.createArrayLiteral(
+          assigns.push(ts.factory.createPropertyAssignment("constructors", ts.factory.createArrayLiteralExpression(
             (type).constructors.map(({modifiers, parameters}) =>
-              ts.createObjectLiteral([
-                ts.createPropertyAssignment("modifiers", ts.createLiteral(modifiers)),
-                ts.createPropertyAssignment("parameters", ts.createArrayLiteral(
-                  parameters.map(({name, modifiers, type}) => ts.createObjectLiteral([
-                    ts.createPropertyAssignment("name", ts.createLiteral(name)),
-                    ts.createPropertyAssignment("modifiers", ts.createLiteral(modifiers)),
-                    ts.createPropertyAssignment("type", makeLiteral(type)),
+              ts.factory.createObjectLiteralExpression([
+                ts.factory.createPropertyAssignment("modifiers", ts.factory.createNumericLiteral(modifiers)),
+                ts.factory.createPropertyAssignment("parameters", ts.factory.createArrayLiteralExpression(
+                  parameters.map(({name, modifiers, type}) => ts.factory.createObjectLiteralExpression([
+                    ts.factory.createPropertyAssignment("name", ts.factory.createStringLiteral(name)),
+                    ts.factory.createPropertyAssignment("modifiers", ts.factory.createNumericLiteral(modifiers)),
+                    ts.factory.createPropertyAssignment("type", makeLiteral(type)),
                   ]))
                 ))
               ])
@@ -54,26 +61,49 @@ export function makeLiteral(type: ReflectedType): ts.ObjectLiteralExpression {
         break
     }
     switch (type.kind) {
-      
+
       case TypeKind.Tuple:
-        assigns.push(ts.createPropertyAssignment("elementTypes", ts.createArrayLiteral(type.elementTypes.map(makeLiteral))))
+        assigns.push(
+          ts.factory.createPropertyAssignment(
+            "elementTypes",
+            ts.factory.createArrayLiteralExpression(
+              type.elementTypes.map(el => makeLiteral(el))
+            )
+          )
+        );
         break
       case TypeKind.Union:
-        assigns.push(ts.createPropertyAssignment("types", ts.createArrayLiteral(type.types.map(makeLiteral))))
+        assigns.push(
+          ts.factory.createPropertyAssignment(
+            "types",
+            ts.factory.createArrayLiteralExpression(
+              type.types.map(tp => makeLiteral(tp))
+            )
+          )
+        );
         break
       case TypeKind.StringLiteral:
+        assigns.push(ts.factory.createPropertyAssignment('value', ts.factory.createStringLiteral(type.value)))
+        break
       case TypeKind.NumberLiteral:
-        assigns.push(ts.createPropertyAssignment('value', ts.createLiteral(type.value)))
+        assigns.push(ts.factory.createPropertyAssignment('value', ts.factory.createNumericLiteral(type.value)))
         break
       case TypeKind.Reference:
-        assigns.push(ts.createPropertyAssignment("type", type.type))
-        assigns.push(ts.createPropertyAssignment("arguments", ts.createArrayLiteral(type.arguments.map(makeLiteral))))
+        assigns.push(ts.factory.createPropertyAssignment("type", type.type))
+        assigns.push(
+          ts.factory.createPropertyAssignment(
+            "arguments",
+            ts.factory.createArrayLiteralExpression(
+              type.arguments.map(arg => makeLiteral(arg))
+            )
+          )
+        );
         break
       case TypeKind.Class:
         if (type.extends !== undefined) {
-          assigns.push(ts.createPropertyAssignment("extends", makeLiteral(type.extends)))
+          assigns.push(ts.factory.createPropertyAssignment("extends", makeLiteral(type.extends)))
         }
         break
     }
-    return ts.createObjectLiteral(assigns)
+    return ts.factory.createObjectLiteralExpression(assigns)
 }

--- a/packages/tsruntime/src/transform/makeLiteral.ts
+++ b/packages/tsruntime/src/transform/makeLiteral.ts
@@ -14,8 +14,8 @@ function getExpressionForPropertyName(name: ts.PropertyName) { //copied from typ
     return name
 }
 
-  
-export function makeLiteral(type: ReflectedType): ts.ObjectLiteralExpression {
+
+export function makeLiteral(type: ReflectedType, modifier?: ts.ModifierFlags): ts.ObjectLiteralExpression {
     const assigns = []
     const kindAssign = ts.factory.createPropertyAssignment("kind", ts.factory.createNumericLiteral(type.kind))
     const kindAssignComment = ts.addSyntheticTrailingComment(kindAssign, ts.SyntaxKind.MultiLineCommentTrivia, TypeKind[type.kind], false)
@@ -23,6 +23,10 @@ export function makeLiteral(type: ReflectedType): ts.ObjectLiteralExpression {
 
     if (type.initializer !== undefined) {
       assigns.push(ts.factory.createPropertyAssignment("initializer", type.initializer))
+    }
+
+    if (modifier !== undefined) {
+      assigns.push(ts.factory.createPropertyAssignment("modifiers", ts.factory.createNumericLiteral(modifier)));
     }
 
     switch (type.kind) {
@@ -36,8 +40,8 @@ export function makeLiteral(type: ReflectedType): ts.ObjectLiteralExpression {
           ts.factory.createPropertyAssignment(
             "properties",
             ts.factory.createObjectLiteralExpression(
-              type.properties.map(({name, type}) =>
-                ts.factory.createPropertyAssignment(getExpressionForPropertyName(name), makeLiteral(type))
+              type.properties.map(({name, type, modifiers}) =>
+                ts.factory.createPropertyAssignment(getExpressionForPropertyName(name), makeLiteral(type, modifiers))
               )
             )
           )

--- a/packages/tsruntime/src/transform/reflect.ts
+++ b/packages/tsruntime/src/transform/reflect.ts
@@ -88,7 +88,7 @@ export function getReflect(ctx: Ctx) {
   function getIdentifierForSymbol(type: ts.Type): ts.Identifier {
     let name: string;
 
-    const typenode = ctx.checker.typeToTypeNode(type, ctx.node, undefined)!; //todo not sure
+    const typenode = ctx.checker.typeToTypeNode(type, ctx.node, undefined, undefined)!; //todo not sure
 
     switch (typenode.kind) {
       case ts.SyntaxKind.TypeReference:
@@ -105,7 +105,7 @@ export function getReflect(ctx: Ctx) {
       default:
         name = type.getSymbol()!.getName();
     }
-    const typeIdentifier = ts.createIdentifier(name);
+    const typeIdentifier = ts.factory.createIdentifier(name);
     (typeIdentifier as any).flags &= ~ts.NodeFlags.Synthesized;
     (typeIdentifier as any).parent = ctx.currentScope;
     return typeIdentifier;
@@ -117,7 +117,7 @@ export function getReflect(ctx: Ctx) {
       // if (!ts.isPropertySignature(valueDeclaration) && !ts.isPropertyDeclaration(valueDeclaration)) {
       // throw new Error("not prop signature");
       // }
-      return (valueDeclaration as ts.PropertyLikeDeclaration).name;
+      return (valueDeclaration as ts.PropertyDeclaration).name;
     }
     //@ts-ignore
     const nameType = symbol.nameType as ts.Type;
@@ -133,7 +133,7 @@ export function getReflect(ctx: Ctx) {
 
   function serializeInitializer(decl: {initializer?: ts.Expression}): ts.ArrowFunction | undefined {
     return decl.initializer
-      ? ts.createArrowFunction(undefined, undefined, [], undefined, undefined, decl.initializer)
+      ? ts.factory.createArrowFunction(undefined, undefined, [], undefined, undefined, decl.initializer)
       : undefined;
   }
 
@@ -154,7 +154,7 @@ export function getReflect(ctx: Ctx) {
     const type = reflectType(ctx.checker.getTypeOfSymbolAtLocation(param, decl));
     const modifiers = ts.getCombinedModifierFlags(decl);
 
-    const initializer = ts.isParameter(param.valueDeclaration!)
+    const initializer = param.valueDeclaration && ts.isParameter(param.valueDeclaration)
       ? serializeInitializer(param.valueDeclaration)
       : undefined;
 

--- a/packages/tsruntime/src/transform/reflect.ts
+++ b/packages/tsruntime/src/transform/reflect.ts
@@ -88,7 +88,7 @@ export function getReflect(ctx: Ctx) {
   function getIdentifierForSymbol(type: ts.Type): ts.Identifier {
     let name: string;
 
-    const typenode = ctx.checker.typeToTypeNode(type, ctx.node, undefined, undefined)!; //todo not sure
+    const typenode = ctx.checker.typeToTypeNode(type, ctx.node, undefined)!; //todo not sure
 
     switch (typenode.kind) {
       case ts.SyntaxKind.TypeReference:
@@ -126,8 +126,8 @@ export function getReflect(ctx: Ctx) {
     if (nameSymb) {
       return nameSymb.valueDeclaration as any;
     } else {
-      //@ts-ignore
-      return ts.createLiteral(nameType.value);
+      //@ts-expect-error
+      return ts.factory.createLiteral(nameType.value);
     }
   }
 

--- a/packages/tsruntime/src/transform/reflect.ts
+++ b/packages/tsruntime/src/transform/reflect.ts
@@ -138,15 +138,21 @@ export function getReflect(ctx: Ctx) {
   }
 
   function serializePropertySymbol(sym: ts.Symbol) {
+    const decl = sym.declarations![0];
     const type = ctx.checker.getTypeOfSymbolAtLocation(sym, ctx.node);
     const serializedType = reflectType(type);
+    const modifierFlags = ts.getCombinedModifierFlags(decl);
 
     const name = getPropertyName(sym);
     const initializer = ts.isPropertyDeclaration(sym.valueDeclaration!)
       ? serializeInitializer(sym.valueDeclaration)
       : undefined;
 
-    return { name: name, type: {...serializedType, initializer} };
+    return {
+      name: name,
+      modifiers: modifierFlags,
+      type: {...serializedType, initializer},
+    };
   }
 
   function serializeConstructorParameter(param: ts.Symbol): ConstructorParameter {

--- a/packages/tsruntime/src/transform/transformer.ts
+++ b/packages/tsruntime/src/transform/transformer.ts
@@ -101,8 +101,13 @@ function Transformer(program: ts.Program, context: ts.TransformationContext) {
     const reflectedType = getReflect(ctx).reflectType(type);
     const literal = makeLiteral(reflectedType);
 
-    const newExpression = ts.createCall(node.expression, undefined, [literal])
-    return ts.updateCall(node, newExpression, node.typeArguments, ts.visitNodes(node.arguments, visitor))
+    const newExpression = ts.factory.createCallExpression(node.expression, undefined, [literal])
+    return ts.factory.updateCallExpression(
+      node,
+      newExpression,
+      node.typeArguments,
+      ts.visitNodes<ts.Expression, ts.NodeArray<ts.Expression>>(node.arguments, visitor) as any
+    );
   }
 
   function visitDecotaror(node: ts.Decorator) {
@@ -113,7 +118,7 @@ function Transformer(program: ts.Program, context: ts.TransformationContext) {
     const ctx = createContext(node)
 
     const classDeclaration = node.parent
-    
+
     const type = checker.getTypeAtLocation(classDeclaration);
 
     if (classDeclaration.kind !== ts.SyntaxKind.ClassDeclaration) {
@@ -125,8 +130,8 @@ function Transformer(program: ts.Program, context: ts.TransformationContext) {
     >type);
     const literal = makeLiteral(reflectedType);
 
-    const newExpression = ts.createCall(node.expression, undefined, [literal]);
-    return ts.updateDecorator(node, newExpression);
+    const newExpression = ts.factory.createCallExpression(node.expression, undefined, [literal]);
+    return ts.factory.updateDecorator(node, newExpression);
   }
 
   function onBeforeVisitNode(node: ts.Node) {

--- a/packages/tsruntime/src/transform/types.ts
+++ b/packages/tsruntime/src/transform/types.ts
@@ -59,7 +59,7 @@ type Override2<T> = Override<T, {}>
 // type Override2<T, O> = T extends {[key: string]: infer R} ? {[key: string]: R extends Types.ReflectedType ? ReflectedType : R}: T
 
 
-type Properties = Array<{ name: ts.PropertyName; type: ReflectedType }>;
+type Properties = Array<{ name: ts.PropertyName; type: ReflectedType; modifiers: Types.ModifierFlags }>;
 export type ObjectType = Override<
   Types.ObjectType,
   {

--- a/yarn.lock
+++ b/yarn.lock
@@ -18,6 +18,31 @@
     esutils "^2.0.2"
     js-tokens "^4.0.0"
 
+"@cspotcode/source-map-support@^0.8.0":
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz#00629c35a688e05a88b1cda684fb9d5e73f000a1"
+  integrity sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==
+  dependencies:
+    "@jridgewell/trace-mapping" "0.3.9"
+
+"@jridgewell/resolve-uri@^3.0.3":
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz#c08679063f279615a3326583ba3a90d1d82cc721"
+  integrity sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==
+
+"@jridgewell/sourcemap-codec@^1.4.10":
+  version "1.4.15"
+  resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz#d7c6e6755c78567a951e04ab52ef0fd26de59f32"
+  integrity sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==
+
+"@jridgewell/trace-mapping@0.3.9":
+  version "0.3.9"
+  resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz#6534fd5933a53ba7cbf3a17615e273a0d1273ff9"
+  integrity sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==
+  dependencies:
+    "@jridgewell/resolve-uri" "^3.0.3"
+    "@jridgewell/sourcemap-codec" "^1.4.10"
+
 "@lerna/add@^3.5.0":
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/@lerna/add/-/add-3.5.0.tgz#3518b3d4afc3743b7227b1ee3534114eb9575888"
@@ -596,6 +621,26 @@
   resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz#2b5a3ab3f918cca48a8c754c08168e3f03eba61b"
   integrity sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==
 
+"@tsconfig/node10@^1.0.7":
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node10/-/node10-1.0.9.tgz#df4907fc07a886922637b15e02d4cebc4c0021b2"
+  integrity sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==
+
+"@tsconfig/node12@^1.0.7":
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node12/-/node12-1.0.11.tgz#ee3def1f27d9ed66dac6e46a295cffb0152e058d"
+  integrity sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==
+
+"@tsconfig/node14@^1.0.0":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node14/-/node14-1.0.3.tgz#e4386316284f00b98435bf40f72f75a09dabf6c1"
+  integrity sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==
+
+"@tsconfig/node16@^1.0.2":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node16/-/node16-1.0.4.tgz#0b92dcc0cc1c81f6f306a381f28e31b1a56536e9"
+  integrity sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==
+
 "@types/jest@^23.3.9":
   version "23.3.10"
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-23.3.10.tgz#4897974cc317bf99d4fe6af1efa15957fa9c94de"
@@ -632,6 +677,11 @@ acorn-walk@^6.0.1:
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-6.1.1.tgz#d363b66f5fac5f018ff9c3a1e7b6f8e310cc3913"
   integrity sha512-OtUw6JUTgxA2QoqqmrmQ7F2NYqiBPi/L2jqHyFtllhOUvXYQXf0Z1CYUinIfyT4bTCGmrA7gX9FvHA81uzCoVw==
 
+acorn-walk@^8.1.1:
+  version "8.3.0"
+  resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.3.0.tgz#2097665af50fd0cf7a2dfccd2b9368964e66540f"
+  integrity sha512-FS7hV565M5l1R08MXqo8odwMTB02C2UqzB17RVgu9EyuYFBqJZ3/ZY97sQD5FewVu1UyDFc1yztUDrAwT0EypA==
+
 acorn@^5.5.3:
   version "5.7.3"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.7.3.tgz#67aa231bf8812974b85235a96771eb6bd07ea279"
@@ -641,6 +691,11 @@ acorn@^6.0.1:
   version "6.0.4"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.0.4.tgz#77377e7353b72ec5104550aa2d2097a2fd40b754"
   integrity sha512-VY4i5EKSKkofY2I+6QLTbTTN/UvEQPCo6eiwzzSaSWfpaDhOmStMCMod6wmuPciNq+XS0faCglFu2lHZpdHUtg==
+
+acorn@^8.4.1:
+  version "8.11.2"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.11.2.tgz#ca0d78b51895be5390a5903c5b3bdcdaf78ae40b"
+  integrity sha512-nc0Axzp/0FILLEVsm4fNwLCwMttvhEI263QtVPQcbpfZZ3ts0hLsZGOpE6czNlid7CJ9MlyH8reXkpsf3YUY4w==
 
 agent-base@4, agent-base@^4.1.0, agent-base@~4.2.0:
   version "4.2.1"
@@ -686,6 +741,11 @@ ansi-regex@^4.0.0:
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.0.0.tgz#70de791edf021404c3fd615aa89118ae0432e5a9"
   integrity sha512-iB5Dda8t/UqpPI/IjsejXu5jOGDrzn41wJyljwPH65VCIbk6+1BzFIMJGFwTNrYXT1CrD+B4l19U7awiQ8rk7w==
 
+ansi-regex@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
+  integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
+
 ansi-styles@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
@@ -697,6 +757,13 @@ ansi-styles@^3.2.0, ansi-styles@^3.2.1:
   integrity sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==
   dependencies:
     color-convert "^1.9.0"
+
+ansi-styles@^4.1.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-4.3.0.tgz#edd803628ae71c04c85ae7a0906edad34b648937"
+  integrity sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==
+  dependencies:
+    color-convert "^2.0.1"
 
 anymatch@^2.0.0:
   version "2.0.0"
@@ -1276,6 +1343,14 @@ chalk@^2.0.0, chalk@^2.0.1, chalk@^2.3.1:
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
+chalk@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
+  integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
+  dependencies:
+    ansi-styles "^4.1.0"
+    supports-color "^7.1.0"
+
 chardet@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
@@ -1360,10 +1435,22 @@ color-convert@^1.9.0:
   dependencies:
     color-name "1.1.3"
 
+color-convert@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-2.0.1.tgz#72d3a68d598c9bdb3af2ad1e84f21d896abd4de3"
+  integrity sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==
+  dependencies:
+    color-name "~1.1.4"
+
 color-name@1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
   integrity sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=
+
+color-name@~1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
+  integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
 columnify@^1.5.4:
   version "1.5.4"
@@ -1552,6 +1639,11 @@ cosmiconfig@^5.0.2:
     is-directory "^0.3.1"
     js-yaml "^3.9.0"
     parse-json "^4.0.0"
+
+create-require@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
+  integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
 
 cross-spawn@^5.0.1:
   version "5.1.0"
@@ -1767,10 +1859,15 @@ dezalgo@^1.0.0:
     asap "^2.0.0"
     wrappy "1"
 
-diff@^3.1.0, diff@^3.2.0:
+diff@^3.2.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
   integrity sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==
+
+diff@^4.0.1:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
+  integrity sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==
 
 dir-glob@^2.0.0:
   version "2.0.0"
@@ -2434,6 +2531,15 @@ glob@^7.1.3:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
+global-prefix@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/global-prefix/-/global-prefix-3.0.0.tgz#fc85f73064df69f50421f47f883fe5b913ba9b97"
+  integrity sha512-awConJSVCHVGND6x3tmMaKcQvwXLhjdkmomy2W+Goaui8YPgYgXJZewhg3fWC+DlfqqQuWg8AwqjGTD2nAPVWg==
+  dependencies:
+    ini "^1.3.5"
+    kind-of "^6.0.2"
+    which "^1.3.1"
+
 globals@^9.18.0:
   version "9.18.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-9.18.0.tgz#aa3896b3e69b487f17e31ed2143d69a8e30c2d8a"
@@ -2502,6 +2608,11 @@ has-flag@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
   integrity sha1-tdRU3CGZriJWmfNGfloH87lVuv0=
+
+has-flag@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-4.0.0.tgz#944771fd9c81c81265c4d6941860da06bb59479b"
+  integrity sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==
 
 has-symbols@^1.0.0:
   version "1.0.0"
@@ -2689,6 +2800,11 @@ ini@^1.3.2, ini@^1.3.4, ini@~1.3.0:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
   integrity sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==
+
+ini@^1.3.5:
+  version "1.3.8"
+  resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.8.tgz#a29da425b48806f34767a4efce397269af28432c"
+  integrity sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==
 
 init-package-json@^1.10.3:
   version "1.10.3"
@@ -3725,6 +3841,13 @@ lru-cache@^4.0.1, lru-cache@^4.1.2, lru-cache@^4.1.3:
     pseudomap "^1.0.2"
     yallist "^2.1.2"
 
+lru-cache@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-6.0.0.tgz#6d6fe6570ebd96aaf90fcad1dafa3b2566db3a94"
+  integrity sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==
+  dependencies:
+    yallist "^4.0.0"
+
 make-dir@^1.0.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-1.3.0.tgz#79c1033b80515bd6d24ec9933e860ca75ee27f0c"
@@ -3938,6 +4061,11 @@ minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
   integrity sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=
+
+minimist@^1.2.8:
+  version "1.2.8"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
+  integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
 
 minimist@~0.0.1:
   version "0.0.10"
@@ -5035,7 +5163,7 @@ resolve@1.x:
   dependencies:
     path-parse "^1.0.5"
 
-resolve@>=1.9.0:
+resolve@^1.22.2:
   version "1.22.8"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.8.tgz#b6c87a9f2aa06dfab52e3d70ac8cde321fa5a48d"
   integrity sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==
@@ -5137,6 +5265,13 @@ sax@^1.2.4:
   version "5.6.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.6.0.tgz#7e74256fbaa49c75aa7c7a205cc22799cac80004"
   integrity sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==
+
+semver@^7.3.8:
+  version "7.5.4"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.5.4.tgz#483986ec4ed38e1c6c48c34894a9182dbff68a6e"
+  integrity sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==
+  dependencies:
+    lru-cache "^6.0.0"
 
 semver@~5.3.0:
   version "5.3.0"
@@ -5462,6 +5597,13 @@ strip-ansi@^5.0.0:
   dependencies:
     ansi-regex "^4.0.0"
 
+strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
 strip-bom@3.0.0, strip-bom@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-3.0.0.tgz#2334c18e9c759f7bdd56fdef7e9ae3d588e68ed3"
@@ -5524,6 +5666,13 @@ supports-color@^5.3.0:
   integrity sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==
   dependencies:
     has-flag "^3.0.0"
+
+supports-color@^7.1.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-7.2.0.tgz#1b7dcdcb32b8138801b3e478ba6a51caa89648da"
+  integrity sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==
+  dependencies:
+    has-flag "^4.0.0"
 
 supports-preserve-symlinks-flag@^1.0.0:
   version "1.0.0"
@@ -5708,28 +5857,41 @@ ts-jest@^23.10.4:
     semver "^5.5"
     yargs-parser "10.x"
 
-ts-node@8.1.0:
-  version "8.1.0"
-  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-8.1.0.tgz#8c4b37036abd448577db22a061fd7a67d47e658e"
-  integrity sha512-34jpuOrxDuf+O6iW1JpgTRDFynUZ1iEqtYruBqh35gICNjN8x+LpVcPAcwzLPi9VU6mdA3ym+x233nZmZp445A==
+ts-node@10.9.1:
+  version "10.9.1"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-10.9.1.tgz#e73de9102958af9e1f0b168a6ff320e25adcff4b"
+  integrity sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==
   dependencies:
+    "@cspotcode/source-map-support" "^0.8.0"
+    "@tsconfig/node10" "^1.0.7"
+    "@tsconfig/node12" "^1.0.7"
+    "@tsconfig/node14" "^1.0.0"
+    "@tsconfig/node16" "^1.0.2"
+    acorn "^8.4.1"
+    acorn-walk "^8.1.1"
     arg "^4.1.0"
-    diff "^3.1.0"
+    create-require "^1.1.0"
+    diff "^4.0.1"
     make-error "^1.1.1"
-    source-map-support "^0.5.6"
-    yn "^3.0.0"
+    v8-compile-cache-lib "^3.0.1"
+    yn "3.1.1"
+
+ts-patch@3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/ts-patch/-/ts-patch-3.0.2.tgz#cbdf88e4dfb596e4dab8f2c8269361d33270a0ba"
+  integrity sha512-iTg8euqiNsNM1VDfOsVIsP0bM4kAVXU38n7TGQSkky7YQX/syh6sDPIRkvSS0HjT8ZOr0pq1h+5Le6jdB3hiJQ==
+  dependencies:
+    chalk "^4.1.2"
+    global-prefix "^3.0.0"
+    minimist "^1.2.8"
+    resolve "^1.22.2"
+    semver "^7.3.8"
+    strip-ansi "^6.0.1"
 
 tslib@^1.9.0:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
   integrity sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==
-
-ttypescript@1.5.15:
-  version "1.5.15"
-  resolved "https://registry.yarnpkg.com/ttypescript/-/ttypescript-1.5.15.tgz#e45550ad69289d06d3bc3fd4a3c87e7c1ef3eba7"
-  integrity sha512-48ykDNHzFnPMnv4hYX1P8Q84TvCZyL1QlFxeuxsuZ48X2+ameBgPenvmCkHJtoOSxpoWTWi8NcgNrRnVDOmfSg==
-  dependencies:
-    resolve ">=1.9.0"
 
 tunnel-agent@^0.6.0:
   version "0.6.0"
@@ -5755,10 +5917,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@4.9.5:
-  version "4.9.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
-  integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
+typescript@5.3.2:
+  version "5.3.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.3.2.tgz#00d1c7c1c46928c5845c1ee8d0cc2791031d4c43"
+  integrity sha512-6l+RyNy7oAHDfxC4FzSJcz9vnjTKxrLpDG5M2Vu4SHRVNg6xzqZp6LYSR9zjqQTu8DU/f5xwxUdADOkbrIX2gQ==
 
 uglify-js@^3.1.4:
   version "3.6.7"
@@ -5849,6 +6011,11 @@ uuid@^3.0.1, uuid@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
   integrity sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==
+
+v8-compile-cache-lib@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz#6336e8d71965cb3d35a1bbb7868445a7c05264bf"
+  integrity sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==
 
 validate-npm-package-license@^3.0.1, validate-npm-package-license@^3.0.3:
   version "3.0.4"
@@ -6046,6 +6213,11 @@ yallist@^3.0.0, yallist@^3.0.2:
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.0.3.tgz#b4b049e314be545e3ce802236d6cd22cd91c3de9"
   integrity sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==
 
+yallist@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
+  integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
+
 yargs-parser@10.x:
   version "10.1.0"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-10.1.0.tgz#7202265b89f7e9e9f2e5765e0fe735a905edbaa8"
@@ -6104,7 +6276,7 @@ yargs@^12.0.1:
     y18n "^3.2.1 || ^4.0.0"
     yargs-parser "^11.1.1"
 
-yn@^3.0.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/yn/-/yn-3.1.0.tgz#fcbe2db63610361afcc5eb9e0ac91e976d046114"
-  integrity sha512-kKfnnYkbTfrAdd0xICNFw7Atm8nKpLcLv9AZGEt+kczL/WQVai4e2V6ZN8U/O+iI6WrNuJjNNOyu4zfhl9D3Hg==
+yn@3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/yn/-/yn-3.1.1.tgz#1e87401a09d767c1d5eab26a6e4c185182d2eb50"
+  integrity sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==


### PR DESCRIPTION
Changes:
- Update `typescript` version to `5.3.2`
- Uninstall `ttypescript`
- Install `ts-patch` to support Typescript v5
- Fix `strict` errors
- Update removed `.create*` calls to `.factory.create*`
- Add modifier information
- Add some props examples