### PR TITLE
Properties Modifiers v3

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "reflect-metadata": "^0.1.10",
     "rimraf": "^2.6.1",
     "ts-jest": "^23.10.4",
-    "ttypescript": "1.5.6",
+    "ttypescript": "1.5.15",
     "typescript": "3.4.4"
   },
   "name": "tsruntime"

--- a/packages/tests/package.json
+++ b/packages/tests/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "scripts": {
     "test": "npm run build && jest --no-cache",
-    "build": "rimraf ./dist && ttsc"
+    "build": "rimraf ./dist && ttsc",
+    "build:watch": "rimraf ./dist && ttsc -w"
   },
   "repository": {
     "type": "git",

--- a/packages/tests/src/types/classConstructor.test.ts
+++ b/packages/tests/src/types/classConstructor.test.ts
@@ -17,12 +17,12 @@ describe("Class Constructor", () => {
         parameters: [
           {
             name: "foo",
-            modifiers: [Types.ModifierFlags.None],
+            modifiers: Types.ModifierFlags.None,
             type: {kind: Types.TypeKind.String},
           },
           {
             name: "bar",
-            modifiers: [Types.ModifierFlags.None],
+            modifiers: Types.ModifierFlags.None,
             type: {kind: Types.TypeKind.Number},
           },
         ],
@@ -44,11 +44,11 @@ describe("Class Constructor", () => {
         parameters: [
           {
             name: "foo",
-            modifiers: [Types.ModifierFlags.Public],
+            modifiers: Types.ModifierFlags.Public,
           },
           {
             name: "bar",
-            modifiers: [Types.ModifierFlags.Private],
+            modifiers: Types.ModifierFlags.Private,
           },
         ],
       },

--- a/packages/tests/src/types/classConstructor.test.ts
+++ b/packages/tests/src/types/classConstructor.test.ts
@@ -17,12 +17,12 @@ describe("Class Constructor", () => {
         parameters: [
           {
             name: "foo",
-            modifiers: 0,
+            modifiers: [Types.ModifierFlags.None],
             type: {kind: Types.TypeKind.String},
           },
           {
             name: "bar",
-            modifiers: 0,
+            modifiers: [Types.ModifierFlags.None],
             type: {kind: Types.TypeKind.Number},
           },
         ],
@@ -44,11 +44,11 @@ describe("Class Constructor", () => {
         parameters: [
           {
             name: "foo",
-            modifiers: Types.ModifierFlags.Public,
+            modifiers: [Types.ModifierFlags.Public],
           },
           {
             name: "bar",
-            modifiers: Types.ModifierFlags.Private,
+            modifiers: [Types.ModifierFlags.Private],
           },
         ],
       },

--- a/packages/tests/src/types/interfaces.test.ts
+++ b/packages/tests/src/types/interfaces.test.ts
@@ -25,7 +25,7 @@ interface IExtends extends IExtended {
 }
 
 
-const stringType = {kind: Types.TypeKind.String}
+const stringType = {kind: Types.TypeKind.String, modifiers: [Types.ModifierFlags.None]}
 
 
 describe("interfaces", () => {
@@ -42,7 +42,7 @@ describe("interfaces", () => {
             [constKey]: stringType,
             ['computed-string']: stringType,
             [uniqSymb]: stringType,
-            method: {kind: Types.TypeKind.Function}
+            method: {kind: Types.TypeKind.Function, modifiers: [Types.ModifierFlags.None]}
         }
     });
   });

--- a/packages/tests/src/types/interfaces.test.ts
+++ b/packages/tests/src/types/interfaces.test.ts
@@ -25,7 +25,7 @@ interface IExtends extends IExtended {
 }
 
 
-const stringType = {kind: Types.TypeKind.String, modifiers: [Types.ModifierFlags.None]}
+const stringType = {kind: Types.TypeKind.String, modifiers: Types.ModifierFlags.None}
 
 
 describe("interfaces", () => {
@@ -42,7 +42,7 @@ describe("interfaces", () => {
             [constKey]: stringType,
             ['computed-string']: stringType,
             [uniqSymb]: stringType,
-            method: {kind: Types.TypeKind.Function, modifiers: [Types.ModifierFlags.None]}
+            method: {kind: Types.TypeKind.Function, modifiers: Types.ModifierFlags.None}
         }
     });
   });

--- a/packages/tests/src/types/objectTypes.test.ts
+++ b/packages/tests/src/types/objectTypes.test.ts
@@ -6,7 +6,7 @@ const constKey = "some-key";
 const uniqSymb = Symbol("some symb");
 
 
-const stringType = {kind: Types.TypeKind.String}
+const stringType = {kind: Types.TypeKind.String, modifiers: [Types.ModifierFlags.None]}
 
 type ObjectType = {
     key: string

--- a/packages/tests/src/types/objectTypes.test.ts
+++ b/packages/tests/src/types/objectTypes.test.ts
@@ -6,7 +6,7 @@ const constKey = "some-key";
 const uniqSymb = Symbol("some symb");
 
 
-const stringType = {kind: Types.TypeKind.String, modifiers: [Types.ModifierFlags.None]}
+const stringType = {kind: Types.TypeKind.String, modifiers: Types.ModifierFlags.None}
 
 type ObjectType = {
     key: string

--- a/packages/tests/src/types/propertyInitializer.test.ts
+++ b/packages/tests/src/types/propertyInitializer.test.ts
@@ -40,17 +40,17 @@ function typeIsEqual(type: Types.ReflectedType, val: any) {
 
 describe("class properties initializers", () => {
   it("primitive types", () => {
-    typeIsEqual(getPropType("string"), { kind: TypeKind.String, modifiers: [Types.ModifierFlags.None] });
+    typeIsEqual(getPropType("string"), { kind: TypeKind.String, modifiers: Types.ModifierFlags.None });
     initializerIsEqual(getPropType("string"), 'string');
-    typeIsEqual(getPropType("number"), { kind: TypeKind.Number, modifiers: [Types.ModifierFlags.None]  });
+    typeIsEqual(getPropType("number"), { kind: TypeKind.Number, modifiers: Types.ModifierFlags.None  });
     initializerIsEqual(getPropType("number"), 42);
-    typeIsEqual(getPropType("true"), { kind: TypeKind.Boolean, modifiers: [Types.ModifierFlags.None]  });
+    typeIsEqual(getPropType("true"), { kind: TypeKind.Boolean, modifiers: Types.ModifierFlags.None  });
     initializerIsEqual(getPropType("true"), true);
-    typeIsEqual(getPropType("false"), { kind: TypeKind.Boolean, modifiers: [Types.ModifierFlags.None]  });
+    typeIsEqual(getPropType("false"), { kind: TypeKind.Boolean, modifiers: Types.ModifierFlags.None  });
     initializerIsEqual(getPropType("false"), false);
-    typeIsEqual(getPropType("null"), { kind: TypeKind.Null, modifiers: [Types.ModifierFlags.None]  });
+    typeIsEqual(getPropType("null"), { kind: TypeKind.Null, modifiers: Types.ModifierFlags.None  });
     initializerIsEqual(getPropType("null"), null);
-    typeIsEqual(getPropType("undefined"), { kind: TypeKind.Undefined, modifiers: [Types.ModifierFlags.None]  });
+    typeIsEqual(getPropType("undefined"), { kind: TypeKind.Undefined, modifiers: Types.ModifierFlags.None  });
     initializerIsEqual(getPropType("undefined"), undefined);
   });
   it("arrays", () => {
@@ -60,7 +60,7 @@ describe("class properties initializers", () => {
       typeIsEqual(type, {
         kind: TypeKind.Reference,
         type: Array,
-        modifiers: [Types.ModifierFlags.None],
+        modifiers: Types.ModifierFlags.None,
         arguments: [{ kind: TypeKind.String }]
       });
       initializerIsEqual(type, ["string"]);
@@ -72,7 +72,7 @@ describe("class properties initializers", () => {
     typeIsEqual(type, {
         kind: TypeKind.Reference,
         type: Cls,
-        modifiers: [Types.ModifierFlags.None],
+        modifiers: Types.ModifierFlags.None,
         arguments: []
       });
       expect(type.initializer).not.toBeUndefined()
@@ -84,7 +84,7 @@ describe("class properties initializers", () => {
     typeIsEqual(type, {
         kind: TypeKind.Reference,
         type: GenericCls,
-        modifiers: [Types.ModifierFlags.None],
+        modifiers: Types.ModifierFlags.None,
         arguments: [{ kind: Types.TypeKind.String }]
       });
       expect(type.initializer).not.toBeUndefined()

--- a/packages/tests/src/types/propertyInitializer.test.ts
+++ b/packages/tests/src/types/propertyInitializer.test.ts
@@ -40,17 +40,17 @@ function typeIsEqual(type: Types.ReflectedType, val: any) {
 
 describe("class properties initializers", () => {
   it("primitive types", () => {
-    typeIsEqual(getPropType("string"), { kind: TypeKind.String });
+    typeIsEqual(getPropType("string"), { kind: TypeKind.String, modifiers: [Types.ModifierFlags.None] });
     initializerIsEqual(getPropType("string"), 'string');
-    typeIsEqual(getPropType("number"), { kind: TypeKind.Number });
+    typeIsEqual(getPropType("number"), { kind: TypeKind.Number, modifiers: [Types.ModifierFlags.None]  });
     initializerIsEqual(getPropType("number"), 42);
-    typeIsEqual(getPropType("true"), { kind: TypeKind.Boolean });
+    typeIsEqual(getPropType("true"), { kind: TypeKind.Boolean, modifiers: [Types.ModifierFlags.None]  });
     initializerIsEqual(getPropType("true"), true);
-    typeIsEqual(getPropType("false"), { kind: TypeKind.Boolean });
+    typeIsEqual(getPropType("false"), { kind: TypeKind.Boolean, modifiers: [Types.ModifierFlags.None]  });
     initializerIsEqual(getPropType("false"), false);
-    typeIsEqual(getPropType("null"), { kind: TypeKind.Null });
+    typeIsEqual(getPropType("null"), { kind: TypeKind.Null, modifiers: [Types.ModifierFlags.None]  });
     initializerIsEqual(getPropType("null"), null);
-    typeIsEqual(getPropType("undefined"), { kind: TypeKind.Undefined });
+    typeIsEqual(getPropType("undefined"), { kind: TypeKind.Undefined, modifiers: [Types.ModifierFlags.None]  });
     initializerIsEqual(getPropType("undefined"), undefined);
   });
   it("arrays", () => {
@@ -60,6 +60,7 @@ describe("class properties initializers", () => {
       typeIsEqual(type, {
         kind: TypeKind.Reference,
         type: Array,
+        modifiers: [Types.ModifierFlags.None],
         arguments: [{ kind: TypeKind.String }]
       });
       initializerIsEqual(type, ["string"]);
@@ -71,6 +72,7 @@ describe("class properties initializers", () => {
     typeIsEqual(type, {
         kind: TypeKind.Reference,
         type: Cls,
+        modifiers: [Types.ModifierFlags.None],
         arguments: []
       });
       expect(type.initializer).not.toBeUndefined()
@@ -82,6 +84,7 @@ describe("class properties initializers", () => {
     typeIsEqual(type, {
         kind: TypeKind.Reference,
         type: GenericCls,
+        modifiers: [Types.ModifierFlags.None],
         arguments: [{ kind: Types.TypeKind.String }]
       });
       expect(type.initializer).not.toBeUndefined()

--- a/packages/tests/src/types/propertyModifiers.test.ts
+++ b/packages/tests/src/types/propertyModifiers.test.ts
@@ -1,0 +1,54 @@
+import {getClassType, Reflective, Types} from "tsruntime";
+
+class Cls {
+  f!: string;
+  protected g!: string;
+  constructor() {
+  }
+}
+
+@Reflective
+abstract class SubCls extends Cls {
+  a!: string;
+  public b!: string;
+  protected c!: string;
+  private d!: string;
+  readonly e!: string;
+  protected readonly g!: string;
+  abstract h: string;
+  protected abstract i: string;
+  public readonly j!: string;
+
+  constructor() {
+    super();
+  }
+}
+
+function getPropModifier(name: string) {
+  const type = getClassType(SubCls);
+  return type.properties[name].modifiers;
+}
+
+function matchModifiers(propName: string, expected: Types.ModifierFlags[]) {
+  expect({
+    name: propName,
+    modifiers: getPropModifier(propName)
+  }).toEqual({
+    name: propName,
+    modifiers: expected
+  });
+}
+
+describe("class properties modifiers", () => {
+  it("matches modifiers", () => {
+    matchModifiers("a", [Types.ModifierFlags.None]);
+    matchModifiers("b", [Types.ModifierFlags.Public]);
+    matchModifiers("c", [Types.ModifierFlags.Protected]);
+    matchModifiers("d", [Types.ModifierFlags.Private]);
+    matchModifiers("e", [Types.ModifierFlags.None, Types.ModifierFlags.Readonly]);
+    matchModifiers("g", [Types.ModifierFlags.Protected, Types.ModifierFlags.Readonly]);
+    matchModifiers("h", [Types.ModifierFlags.None, Types.ModifierFlags.Abstract]);
+    matchModifiers("i", [Types.ModifierFlags.Protected, Types.ModifierFlags.Abstract]);
+    matchModifiers("j", [Types.ModifierFlags.Public, Types.ModifierFlags.Readonly]);
+  });
+});

--- a/packages/tests/src/types/propertyModifiers.test.ts
+++ b/packages/tests/src/types/propertyModifiers.test.ts
@@ -1,4 +1,4 @@
-import {getClassType, Reflective, Types} from "tsruntime";
+import {getClassType, hasModifier, Reflective, Types} from "tsruntime";
 
 class Cls {
   f!: string;
@@ -24,19 +24,23 @@ abstract class SubCls extends Cls {
   }
 }
 
-function getPropModifier(name: string) {
+function getProperty(name: string) {
   const type = getClassType(SubCls);
-  return type.properties[name].modifiers;
+  return type.properties[name];
 }
 
 function matchModifiers(propName: string, expected: Types.ModifierFlags[]) {
-  expect({
-    name: propName,
-    modifiers: getPropModifier(propName)
-  }).toEqual({
-    name: propName,
-    modifiers: expected
-  });
+  for (const modifierFlag of expected) {
+    expect({
+      name: propName,
+      modifierFlag,
+      hasModifier: hasModifier(getProperty(propName) as any as {modifiers: number}, modifierFlag)
+    }).toEqual({
+      name: propName,
+      modifierFlag,
+      hasModifier: true
+    });
+  }
 }
 
 describe("class properties modifiers", () => {
@@ -45,9 +49,9 @@ describe("class properties modifiers", () => {
     matchModifiers("b", [Types.ModifierFlags.Public]);
     matchModifiers("c", [Types.ModifierFlags.Protected]);
     matchModifiers("d", [Types.ModifierFlags.Private]);
-    matchModifiers("e", [Types.ModifierFlags.None, Types.ModifierFlags.Readonly]);
+    matchModifiers("e", [Types.ModifierFlags.Readonly]);
     matchModifiers("g", [Types.ModifierFlags.Protected, Types.ModifierFlags.Readonly]);
-    matchModifiers("h", [Types.ModifierFlags.None, Types.ModifierFlags.Abstract]);
+    matchModifiers("h", [Types.ModifierFlags.Abstract]);
     matchModifiers("i", [Types.ModifierFlags.Protected, Types.ModifierFlags.Abstract]);
     matchModifiers("j", [Types.ModifierFlags.Public, Types.ModifierFlags.Readonly]);
   });

--- a/packages/tests/src/types/transform.test.ts
+++ b/packages/tests/src/types/transform.test.ts
@@ -39,7 +39,7 @@ describe("transform", () => {
         exported: {
           kind: Types.TypeKind.Reference,
           type: ExportedClass,
-          modifiers: [Types.ModifierFlags.None],
+          modifiers: Types.ModifierFlags.None,
           arguments: []
         }
       },
@@ -71,7 +71,7 @@ describe("transform", () => {
       name: "TestClass",
       kind: Types.TypeKind.Class,
       properties: {
-        prop: { kind: Types.TypeKind.String, modifiers: [Types.ModifierFlags.None] }
+        prop: { kind: Types.TypeKind.String, modifiers: Types.ModifierFlags.None }
       },
       constructors: [{modifiers: 0, parameters: []}],
     });

--- a/packages/tests/src/types/transform.test.ts
+++ b/packages/tests/src/types/transform.test.ts
@@ -39,6 +39,7 @@ describe("transform", () => {
         exported: {
           kind: Types.TypeKind.Reference,
           type: ExportedClass,
+          modifiers: [Types.ModifierFlags.None],
           arguments: []
         }
       },
@@ -70,7 +71,7 @@ describe("transform", () => {
       name: "TestClass",
       kind: Types.TypeKind.Class,
       properties: {
-        prop: { kind: Types.TypeKind.String }
+        prop: { kind: Types.TypeKind.String, modifiers: [Types.ModifierFlags.None] }
       },
       constructors: [{modifiers: 0, parameters: []}],
     });

--- a/packages/tsruntime/src/runtime/hasModifier.ts
+++ b/packages/tsruntime/src/runtime/hasModifier.ts
@@ -1,0 +1,8 @@
+import { ModifierFlags } from './publicTypes';
+
+export const hasModifier = (type: { modifiers: number }, modifier: ModifierFlags) => {
+  if (modifier === type.modifiers) {
+    return true;
+  }
+  return !!(type.modifiers & modifier);
+}

--- a/packages/tsruntime/src/runtime/index.ts
+++ b/packages/tsruntime/src/runtime/index.ts
@@ -1,6 +1,7 @@
 export * from './reflect'
 export * from './classUtils'
 export * from './common'
+export * from './hasModifier'
 
 import * as Types from './publicTypes';
 export {Types}

--- a/packages/tsruntime/src/runtime/publicTypes.ts
+++ b/packages/tsruntime/src/runtime/publicTypes.ts
@@ -1,3 +1,7 @@
+import { ModifierFlags } from "typescript";
+
+export { ModifierFlags } from "typescript";
+
 export enum TypeKind {
   Any = 1,
   String,
@@ -25,28 +29,6 @@ export enum TypeKind {
   Function,
 
   Unknown2 = 999
-}
-
-export enum ModifierFlags {
-  None = 0,
-  Export = 1,
-  Ambient = 2,
-  Public = 4,
-  Private = 8,
-  Protected = 16,
-  Static = 32,
-  Readonly = 64,
-  Abstract = 128,
-  Async = 256,
-  Default = 512,
-  Const = 2048,
-  HasComputedFlags = 536870912,
-  AccessibilityModifier = 28,
-  ParameterPropertyModifier = 92,
-  NonPublicAccessibilityModifier = 24,
-  TypeScriptModifier = 2270,
-  ExportDefault = 513,
-  All = 3071
 }
 
 export type StringType = BaseType<TypeKind.String, string>;
@@ -78,7 +60,7 @@ export type SimpleTypes =
   | UnknownType
   | Unknown2Type;
 
-  
+
 
 export type ReflectedType =
   | ObjectType

--- a/packages/tsruntime/src/runtime/publicTypes.ts
+++ b/packages/tsruntime/src/runtime/publicTypes.ts
@@ -1,6 +1,24 @@
-import { ModifierFlags } from "typescript";
-
-export { ModifierFlags } from "typescript";
+export enum ModifierFlags {
+  None = 0,
+  Export = 1,
+  Ambient = 2,
+  Public = 4,
+  Private = 8,
+  Protected = 16,
+  Static = 32,
+  Readonly = 64,
+  Abstract = 128,
+  Async = 256,
+  Default = 512,
+  Const = 2048,
+  HasComputedFlags = 536870912,
+  AccessibilityModifier = 28,
+  ParameterPropertyModifier = 92,
+  NonPublicAccessibilityModifier = 24,
+  TypeScriptModifier = 2270,
+  ExportDefault = 513,
+  All = 3071
+}
 
 export enum TypeKind {
   Any = 1,

--- a/packages/tsruntime/src/runtime/publicTypes.ts
+++ b/packages/tsruntime/src/runtime/publicTypes.ts
@@ -75,6 +75,7 @@ export type ReflectedType =
 
 export interface BaseType<TKind extends TypeKind, T> {
   kind: TKind;
+  modifiers?: ModifierFlags | undefined;
   initializer?: () => T;
 }
 

--- a/packages/tsruntime/src/transform/makeLiteral.ts
+++ b/packages/tsruntime/src/transform/makeLiteral.ts
@@ -15,7 +15,7 @@ function getExpressionForPropertyName(name: ts.PropertyName) { //copied from typ
 }
 
 
-export function makeLiteral(type: ReflectedType, modifiers?: ts.ModifierFlags): ts.ObjectLiteralExpression {
+export function makeLiteral(type: ReflectedType, modifier?: ts.ModifierFlags): ts.ObjectLiteralExpression {
     const assigns = []
     const kindAssign = ts.createPropertyAssignment("kind", ts.createLiteral(type.kind))
     const kindAssignComment = ts.addSyntheticTrailingComment(kindAssign, ts.SyntaxKind.MultiLineCommentTrivia, TypeKind[type.kind], false)
@@ -25,11 +25,8 @@ export function makeLiteral(type: ReflectedType, modifiers?: ts.ModifierFlags): 
       assigns.push(ts.createPropertyAssignment("initializer", type.initializer))
     }
 
-  if (typeof modifiers !== 'undefined') {
-    assigns.push(ts.createPropertyAssignment(
-      "modifiers",
-      ts.createLiteral(modifiers)
-    ));
+  if (modifier !== undefined) {
+    assigns.push(ts.createPropertyAssignment("modifiers", ts.createLiteral(modifier)));
   }
 
     switch (type.kind) {
@@ -51,10 +48,7 @@ export function makeLiteral(type: ReflectedType, modifiers?: ts.ModifierFlags): 
                 ts.createPropertyAssignment("parameters", ts.createArrayLiteral(
                   parameters.map(({name, modifiers, type}) => ts.createObjectLiteral([
                     ts.createPropertyAssignment("name", ts.createLiteral(name)),
-                    ts.createPropertyAssignment(
-                      "modifiers",
-                      ts.createLiteral(modifiers)
-                    ),
+                    ts.createPropertyAssignment("modifiers", ts.createLiteral(modifiers)),
                     ts.createPropertyAssignment("type", makeLiteral(type)),
                   ]))
                 ))

--- a/packages/tsruntime/src/transform/makeLiteral.ts
+++ b/packages/tsruntime/src/transform/makeLiteral.ts
@@ -15,7 +15,7 @@ function getExpressionForPropertyName(name: ts.PropertyName) { //copied from typ
 }
 
 
-export function makeLiteral(type: ReflectedType, modifiers?: ts.ModifierFlags[]): ts.ObjectLiteralExpression {
+export function makeLiteral(type: ReflectedType, modifiers?: ts.ModifierFlags): ts.ObjectLiteralExpression {
     const assigns = []
     const kindAssign = ts.createPropertyAssignment("kind", ts.createLiteral(type.kind))
     const kindAssignComment = ts.addSyntheticTrailingComment(kindAssign, ts.SyntaxKind.MultiLineCommentTrivia, TypeKind[type.kind], false)
@@ -25,12 +25,10 @@ export function makeLiteral(type: ReflectedType, modifiers?: ts.ModifierFlags[])
       assigns.push(ts.createPropertyAssignment("initializer", type.initializer))
     }
 
-  if (Array.isArray(modifiers)) {
+  if (typeof modifiers !== 'undefined') {
     assigns.push(ts.createPropertyAssignment(
       "modifiers",
-      ts.createArrayLiteral(
-        modifiers.map(mod => ts.createLiteral(mod))
-      )
+      ts.createLiteral(modifiers)
     ));
   }
 
@@ -55,7 +53,7 @@ export function makeLiteral(type: ReflectedType, modifiers?: ts.ModifierFlags[])
                     ts.createPropertyAssignment("name", ts.createLiteral(name)),
                     ts.createPropertyAssignment(
                       "modifiers",
-                      ts.createArrayLiteral(modifiers.map(mod => ts.createLiteral(mod)))
+                      ts.createLiteral(modifiers)
                     ),
                     ts.createPropertyAssignment("type", makeLiteral(type)),
                   ]))

--- a/packages/tsruntime/src/transform/reflect.ts
+++ b/packages/tsruntime/src/transform/reflect.ts
@@ -1,6 +1,5 @@
 import * as ts from "typescript";
 import {ClassType, Constructor, ConstructorParameter, Ctx, ReflectedType, TypeKind} from "./types";
-import {Types} from "../runtime";
 
 namespace Normalizers {
   function normalizeBooleans(types: ReflectedType[]): ReflectedType[] {
@@ -56,12 +55,6 @@ namespace Normalizers {
 }
 
 export function getReflect(ctx: Ctx) {
-  const accessModifiers = [
-    ts.ModifierFlags.Private,
-    ts.ModifierFlags.Protected,
-    ts.ModifierFlags.Public,
-  ];
-
   function serializeUnion(type: ts.UnionType): ReflectedType {
     const nestedTypes = type.types.map(t => reflectType(t));
     const normalizedTypes = Normalizers.normalizeUnion(nestedTypes);
@@ -148,14 +141,7 @@ export function getReflect(ctx: Ctx) {
     const decl = sym.declarations![0];
     const type = ctx.checker.getTypeOfSymbolAtLocation(sym, ctx.node);
     const serializedType = reflectType(type);
-    const modifiers = getModifiersFromDeclaration(decl, [
-      ts.ModifierFlags.Private,
-      ts.ModifierFlags.Protected,
-      ts.ModifierFlags.Public,
-      ts.ModifierFlags.Readonly,
-      ts.ModifierFlags.Static,
-      ts.ModifierFlags.Abstract,
-    ]);
+    const modifiers = ts.getCombinedModifierFlags(decl);
 
     const name = getPropertyName(sym);
     const initializer = ts.isPropertyDeclaration(sym.valueDeclaration)
@@ -172,12 +158,7 @@ export function getReflect(ctx: Ctx) {
   function serializeConstructorParameter(param: ts.Symbol): ConstructorParameter {
     const decl = param.declarations[0];
     const type = reflectType(ctx.checker.getTypeOfSymbolAtLocation(param, decl));
-    const modifiers = getModifiersFromDeclaration(decl, [
-      ts.ModifierFlags.Private,
-      ts.ModifierFlags.Protected,
-      ts.ModifierFlags.Public,
-      ts.ModifierFlags.Readonly,
-    ]);
+    const modifiers = ts.getCombinedModifierFlags(decl);
 
     const initializer = ts.isParameter(param.valueDeclaration)
       ? serializeInitializer(param.valueDeclaration)
@@ -245,34 +226,6 @@ export function getReflect(ctx: Ctx) {
     // }
     // ctx.reportUnknownType(type);
     // return { kind: TypeKind.Unknown2 };
-  }
-
-  function getModifiersFromDeclaration(decl: ts.Declaration, includesModifiers: ts.ModifierFlags[] = []) {
-    const modifierFlags = ts.getCombinedModifierFlags(decl);
-    const modifiers = modifierFlags === 0
-      ? [ts.ModifierFlags.None]
-      : getModifiersByBruteForce(modifierFlags).filter(mod => includesModifiers.length === 0 || includesModifiers.includes(mod));
-
-    if (!modifiers.some(mod => accessModifiers.includes(mod)) && !modifiers.includes(ts.ModifierFlags.None)) {
-      modifiers.push(ts.ModifierFlags.None);
-    }
-    return modifiers.sort((a, b) => Number(a) - Number(b));
-  }
-
-  function getModifiersByBruteForce(modifierFlags: ts.ModifierFlags) {
-    const modifiers = [];
-    const modifiersToCheck = Object
-      .keys(ts.ModifierFlags)
-      .filter(k => isNaN(Number(k)))
-      .map(k => ts.ModifierFlags[k as keyof typeof ts.ModifierFlags]);
-
-    for (const mod of modifiersToCheck) {
-      if (modifierFlags & mod) {
-        modifiers.push(mod);
-      }
-    }
-
-    return modifiers;
   }
 
   function reflectType(type: ts.Type): ReflectedType {

--- a/packages/tsruntime/src/transform/reflect.ts
+++ b/packages/tsruntime/src/transform/reflect.ts
@@ -1,5 +1,6 @@
 import * as ts from "typescript";
 import {ClassType, Constructor, ConstructorParameter, Ctx, ReflectedType, TypeKind} from "./types";
+import {Types} from "../runtime";
 
 namespace Normalizers {
   function normalizeBooleans(types: ReflectedType[]): ReflectedType[] {
@@ -55,6 +56,12 @@ namespace Normalizers {
 }
 
 export function getReflect(ctx: Ctx) {
+  const accessModifiers = [
+    Types.ModifierFlags.Private,
+    Types.ModifierFlags.Protected,
+    Types.ModifierFlags.Public,
+  ];
+
   function serializeUnion(type: ts.UnionType): ReflectedType {
     const nestedTypes = type.types.map(t => reflectType(t));
     const normalizedTypes = Normalizers.normalizeUnion(nestedTypes);
@@ -138,21 +145,39 @@ export function getReflect(ctx: Ctx) {
   }
 
   function serializePropertySymbol(sym: ts.Symbol) {
+    const decl = sym.declarations![0];
     const type = ctx.checker.getTypeOfSymbolAtLocation(sym, ctx.node);
     const serializedType = reflectType(type);
+    const modifiers = getModifiersFromDeclaration(decl, [
+      Types.ModifierFlags.Private,
+      Types.ModifierFlags.Protected,
+      Types.ModifierFlags.Public,
+      Types.ModifierFlags.Readonly,
+      Types.ModifierFlags.Static,
+      Types.ModifierFlags.Abstract,
+    ]);
 
     const name = getPropertyName(sym);
     const initializer = ts.isPropertyDeclaration(sym.valueDeclaration)
       ? serializeInitializer(sym.valueDeclaration)
       : undefined;
-      
-    return { name: name, type: {...serializedType, initializer} };
+
+    return {
+      name: name,
+      modifiers,
+      type: {...serializedType, initializer},
+    };
   }
 
   function serializeConstructorParameter(param: ts.Symbol): ConstructorParameter {
     const decl = param.declarations[0];
     const type = reflectType(ctx.checker.getTypeOfSymbolAtLocation(param, decl));
-    const modifiers = ts.getCombinedModifierFlags(decl);
+    const modifiers = getModifiersFromDeclaration(decl, [
+      Types.ModifierFlags.Private,
+      Types.ModifierFlags.Protected,
+      Types.ModifierFlags.Public,
+      Types.ModifierFlags.Readonly,
+    ]);
 
     const initializer = ts.isParameter(param.valueDeclaration)
       ? serializeInitializer(param.valueDeclaration)
@@ -182,7 +207,7 @@ export function getReflect(ctx: Ctx) {
     let properties = ctx.checker
       .getPropertiesOfType(type)
       .map(serializePropertySymbol);
-      
+
     let name;
     if (type.objectFlags & ts.ObjectFlags.Anonymous) {
       name = undefined;
@@ -220,6 +245,34 @@ export function getReflect(ctx: Ctx) {
     // }
     // ctx.reportUnknownType(type);
     // return { kind: TypeKind.Unknown2 };
+  }
+
+  function getModifiersFromDeclaration(decl: ts.Declaration, includesModifiers: Types.ModifierFlags[] = []) {
+    const modifierFlags = ts.getCombinedModifierFlags(decl);
+    const modifiers = modifierFlags === 0
+      ? [Types.ModifierFlags.None]
+      : getModifiersByBruteForce(modifierFlags).filter(mod => includesModifiers.length === 0 || includesModifiers.includes(mod));
+
+    if (!modifiers.some(mod => accessModifiers.includes(mod)) && !modifiers.includes(Types.ModifierFlags.None)) {
+      modifiers.push(Types.ModifierFlags.None);
+    }
+    return modifiers.sort((a, b) => Number(a) - Number(b));
+  }
+
+  function getModifiersByBruteForce(modifierFlags: ts.ModifierFlags) {
+    const modifiers = [];
+    const modifiersToCheck = Object
+      .keys(Types.ModifierFlags)
+      .filter(k => isNaN(Number(k)))
+      .map(k => Types.ModifierFlags[k as keyof typeof Types.ModifierFlags]);
+
+    for (const mod of modifiersToCheck) {
+      if (modifierFlags & mod) {
+        modifiers.push(mod);
+      }
+    }
+
+    return modifiers;
   }
 
   function reflectType(type: ts.Type): ReflectedType {

--- a/packages/tsruntime/src/transform/reflect.ts
+++ b/packages/tsruntime/src/transform/reflect.ts
@@ -57,9 +57,9 @@ namespace Normalizers {
 
 export function getReflect(ctx: Ctx) {
   const accessModifiers = [
-    Types.ModifierFlags.Private,
-    Types.ModifierFlags.Protected,
-    Types.ModifierFlags.Public,
+    ts.ModifierFlags.Private,
+    ts.ModifierFlags.Protected,
+    ts.ModifierFlags.Public,
   ];
 
   function serializeUnion(type: ts.UnionType): ReflectedType {
@@ -149,12 +149,12 @@ export function getReflect(ctx: Ctx) {
     const type = ctx.checker.getTypeOfSymbolAtLocation(sym, ctx.node);
     const serializedType = reflectType(type);
     const modifiers = getModifiersFromDeclaration(decl, [
-      Types.ModifierFlags.Private,
-      Types.ModifierFlags.Protected,
-      Types.ModifierFlags.Public,
-      Types.ModifierFlags.Readonly,
-      Types.ModifierFlags.Static,
-      Types.ModifierFlags.Abstract,
+      ts.ModifierFlags.Private,
+      ts.ModifierFlags.Protected,
+      ts.ModifierFlags.Public,
+      ts.ModifierFlags.Readonly,
+      ts.ModifierFlags.Static,
+      ts.ModifierFlags.Abstract,
     ]);
 
     const name = getPropertyName(sym);
@@ -173,10 +173,10 @@ export function getReflect(ctx: Ctx) {
     const decl = param.declarations[0];
     const type = reflectType(ctx.checker.getTypeOfSymbolAtLocation(param, decl));
     const modifiers = getModifiersFromDeclaration(decl, [
-      Types.ModifierFlags.Private,
-      Types.ModifierFlags.Protected,
-      Types.ModifierFlags.Public,
-      Types.ModifierFlags.Readonly,
+      ts.ModifierFlags.Private,
+      ts.ModifierFlags.Protected,
+      ts.ModifierFlags.Public,
+      ts.ModifierFlags.Readonly,
     ]);
 
     const initializer = ts.isParameter(param.valueDeclaration)
@@ -247,14 +247,14 @@ export function getReflect(ctx: Ctx) {
     // return { kind: TypeKind.Unknown2 };
   }
 
-  function getModifiersFromDeclaration(decl: ts.Declaration, includesModifiers: Types.ModifierFlags[] = []) {
+  function getModifiersFromDeclaration(decl: ts.Declaration, includesModifiers: ts.ModifierFlags[] = []) {
     const modifierFlags = ts.getCombinedModifierFlags(decl);
     const modifiers = modifierFlags === 0
-      ? [Types.ModifierFlags.None]
+      ? [ts.ModifierFlags.None]
       : getModifiersByBruteForce(modifierFlags).filter(mod => includesModifiers.length === 0 || includesModifiers.includes(mod));
 
-    if (!modifiers.some(mod => accessModifiers.includes(mod)) && !modifiers.includes(Types.ModifierFlags.None)) {
-      modifiers.push(Types.ModifierFlags.None);
+    if (!modifiers.some(mod => accessModifiers.includes(mod)) && !modifiers.includes(ts.ModifierFlags.None)) {
+      modifiers.push(ts.ModifierFlags.None);
     }
     return modifiers.sort((a, b) => Number(a) - Number(b));
   }
@@ -262,9 +262,9 @@ export function getReflect(ctx: Ctx) {
   function getModifiersByBruteForce(modifierFlags: ts.ModifierFlags) {
     const modifiers = [];
     const modifiersToCheck = Object
-      .keys(Types.ModifierFlags)
+      .keys(ts.ModifierFlags)
       .filter(k => isNaN(Number(k)))
-      .map(k => Types.ModifierFlags[k as keyof typeof Types.ModifierFlags]);
+      .map(k => ts.ModifierFlags[k as keyof typeof ts.ModifierFlags]);
 
     for (const mod of modifiersToCheck) {
       if (modifierFlags & mod) {

--- a/packages/tsruntime/src/transform/types.ts
+++ b/packages/tsruntime/src/transform/types.ts
@@ -59,7 +59,7 @@ type Override2<T> = Override<T, {}>
 // type Override2<T, O> = T extends {[key: string]: infer R} ? {[key: string]: R extends Types.ReflectedType ? ReflectedType : R}: T
 
 
-type Properties = Array<{ name: ts.PropertyName; type: ReflectedType }>;
+type Properties = Array<{ name: ts.PropertyName; type: ReflectedType; modifiers: Types.ModifierFlags[] }>;
 export type ObjectType = Override<
   Types.ObjectType,
   {
@@ -90,7 +90,7 @@ export type ReferenceType = Override<
 
 export interface ConstructorParameter {
   name: string;
-  modifiers: ts.ModifierFlags;
+  modifiers: ts.ModifierFlags[];
   type: ReflectedType;
 }
 

--- a/packages/tsruntime/src/transform/types.ts
+++ b/packages/tsruntime/src/transform/types.ts
@@ -59,7 +59,7 @@ type Override2<T> = Override<T, {}>
 // type Override2<T, O> = T extends {[key: string]: infer R} ? {[key: string]: R extends Types.ReflectedType ? ReflectedType : R}: T
 
 
-type Properties = Array<{ name: ts.PropertyName; type: ReflectedType; modifiers: Types.ModifierFlags[] }>;
+type Properties = Array<{ name: ts.PropertyName; type: ReflectedType; modifiers: Types.ModifierFlags }>;
 export type ObjectType = Override<
   Types.ObjectType,
   {
@@ -90,7 +90,7 @@ export type ReferenceType = Override<
 
 export interface ConstructorParameter {
   name: string;
-  modifiers: ts.ModifierFlags[];
+  modifiers: ts.ModifierFlags;
   type: ReflectedType;
 }
 

--- a/packages/tsruntime/tsconfig.json
+++ b/packages/tsruntime/tsconfig.json
@@ -2,7 +2,8 @@
 {
     "extends": "../../tsconfig.json",
     "compilerOptions": {
-        "outDir": "dist",
+        "lib": ["dom", "es2016"],
+        "outDir": "dist"
     },
     "include": [
         "src/**/*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2274,6 +2274,11 @@ function-bind@^1.1.1:
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
   integrity sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==
 
+function-bind@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.2.tgz#2c02d864d97f3ea6c8830c464cbd11ab6eab7a1c"
+  integrity sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==
+
 gauge@~2.7.3:
   version "2.7.4"
   resolved "https://registry.yarnpkg.com/gauge/-/gauge-2.7.4.tgz#2c03405c7538c39d7eb37b317022e325fb018bf7"
@@ -2546,6 +2551,13 @@ has@^1.0.1:
   dependencies:
     function-bind "^1.1.1"
 
+hasown@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/hasown/-/hasown-2.0.0.tgz#f4c513d454a57b7c7e1650778de226b11700546c"
+  integrity sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA==
+  dependencies:
+    function-bind "^1.1.2"
+
 home-or-tmp@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/home-or-tmp/-/home-or-tmp-2.0.0.tgz#e36c3f2d2cae7d746a857e38d18d5f32a7882db8"
@@ -2775,6 +2787,13 @@ is-ci@^1.0.10:
   integrity sha512-s6tfsaQaQi3JNciBH6shVqEDvhGut0SUXr31ag8Pd8BBbVVlcGfWhpPmEOoM6RJ5TFhbypvf5yyRw/VXW1IiWg==
   dependencies:
     ci-info "^1.5.0"
+
+is-core-module@^2.13.0:
+  version "2.13.1"
+  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.13.1.tgz#ad0d7532c6fea9da1ebdc82742d74525c6273384"
+  integrity sha512-hHrIjvZsftOsvKSn2TRYl63zvxsgE0K+0mYMoH6gD4omR5IWB2KynivBQczo3+wF1cCkjzvptnI9Q0sPU66ilw==
+  dependencies:
+    hasown "^2.0.0"
 
 is-data-descriptor@^0.1.4:
   version "0.1.4"
@@ -4554,6 +4573,11 @@ path-parse@^1.0.5, path-parse@^1.0.6:
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.6.tgz#d62dbb5679405d72c4737ec58600e9ddcf06d24c"
   integrity sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==
 
+path-parse@^1.0.7:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.7.tgz#fbc114b60ca42b30d9daf5858e4bd68bbedb6735"
+  integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
+
 path-type@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-1.1.0.tgz#59c44f7ee491da704da415da5a4070ba4f8fe441"
@@ -5010,6 +5034,15 @@ resolve@1.x:
   integrity sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==
   dependencies:
     path-parse "^1.0.5"
+
+resolve@>=1.9.0:
+  version "1.22.8"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.8.tgz#b6c87a9f2aa06dfab52e3d70ac8cde321fa5a48d"
+  integrity sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==
+  dependencies:
+    is-core-module "^2.13.0"
+    path-parse "^1.0.7"
+    supports-preserve-symlinks-flag "^1.0.0"
 
 resolve@^1.9.0:
   version "1.10.0"
@@ -5499,6 +5532,11 @@ supports-color@^5.3.0:
   dependencies:
     has-flag "^3.0.0"
 
+supports-preserve-symlinks-flag@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
+  integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
+
 symbol-tree@^3.2.2:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.2.tgz#ae27db38f660a7ae2e1c3b7d1bc290819b8519e6"
@@ -5706,6 +5744,13 @@ tslib@^1.9.0:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
   integrity sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==
+
+ttypescript@1.5.15:
+  version "1.5.15"
+  resolved "https://registry.yarnpkg.com/ttypescript/-/ttypescript-1.5.15.tgz#e45550ad69289d06d3bc3fd4a3c87e7c1ef3eba7"
+  integrity sha512-48ykDNHzFnPMnv4hYX1P8Q84TvCZyL1QlFxeuxsuZ48X2+ameBgPenvmCkHJtoOSxpoWTWi8NcgNrRnVDOmfSg==
+  dependencies:
+    resolve ">=1.9.0"
 
 ttypescript@1.5.6:
   version "1.5.6"


### PR DESCRIPTION
## Purpose
Extract all modifiers from `ts.getCombinedModifierFlags`, which returns a combination of all modifier flags.

**Example**: If I have a `public readonly` property, the `ts.getCombinedModifierFlags` call returns 68, 4 (public) + 64 (readonly).

## Use case

I want expose the properties that have `None` or `Public` modifier to a Schema/DTO.