### PR TITLE
Properties Modifiers v4

### DIFF
--- a/packages/tests/package.json
+++ b/packages/tests/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "scripts": {
     "test": "npm run build && jest --no-cache",
-    "build": "rimraf ./dist && ttsc"
+    "build": "rimraf ./dist && ttsc",
+    "build:watch": "rimraf ./dist && ttsc -w"
   },
   "repository": {
     "type": "git",

--- a/packages/tests/src/types/classConstructor.test.ts
+++ b/packages/tests/src/types/classConstructor.test.ts
@@ -17,12 +17,12 @@ describe("Class Constructor", () => {
         parameters: [
           {
             name: "foo",
-            modifiers: [Types.ModifierFlags.None],
+            modifiers: Types.ModifierFlags.None,
             type: {kind: Types.TypeKind.String},
           },
           {
             name: "bar",
-            modifiers: [Types.ModifierFlags.None],
+            modifiers: Types.ModifierFlags.None,
             type: {kind: Types.TypeKind.Number},
           },
         ],
@@ -44,11 +44,11 @@ describe("Class Constructor", () => {
         parameters: [
           {
             name: "foo",
-            modifiers: [Types.ModifierFlags.Public],
+            modifiers: Types.ModifierFlags.Public,
           },
           {
             name: "bar",
-            modifiers: [Types.ModifierFlags.Private],
+            modifiers: Types.ModifierFlags.Private,
           },
         ],
       },

--- a/packages/tests/src/types/classConstructor.test.ts
+++ b/packages/tests/src/types/classConstructor.test.ts
@@ -17,12 +17,12 @@ describe("Class Constructor", () => {
         parameters: [
           {
             name: "foo",
-            modifiers: 0,
+            modifiers: [Types.ModifierFlags.None],
             type: {kind: Types.TypeKind.String},
           },
           {
             name: "bar",
-            modifiers: 0,
+            modifiers: [Types.ModifierFlags.None],
             type: {kind: Types.TypeKind.Number},
           },
         ],
@@ -44,11 +44,11 @@ describe("Class Constructor", () => {
         parameters: [
           {
             name: "foo",
-            modifiers: Types.ModifierFlags.Public,
+            modifiers: [Types.ModifierFlags.Public],
           },
           {
             name: "bar",
-            modifiers: Types.ModifierFlags.Private,
+            modifiers: [Types.ModifierFlags.Private],
           },
         ],
       },

--- a/packages/tests/src/types/interfaces.test.ts
+++ b/packages/tests/src/types/interfaces.test.ts
@@ -25,7 +25,7 @@ interface IExtends extends IExtended {
 }
 
 
-const stringType = {kind: Types.TypeKind.String}
+const stringType = {kind: Types.TypeKind.String, modifiers: [Types.ModifierFlags.None]}
 
 
 describe("interfaces", () => {
@@ -42,7 +42,7 @@ describe("interfaces", () => {
             [constKey]: stringType,
             ['computed-string']: stringType,
             [uniqSymb]: stringType,
-            method: {kind: Types.TypeKind.Function}
+            method: {kind: Types.TypeKind.Function, modifiers: [Types.ModifierFlags.None]}
         }
     });
   });

--- a/packages/tests/src/types/interfaces.test.ts
+++ b/packages/tests/src/types/interfaces.test.ts
@@ -25,7 +25,7 @@ interface IExtends extends IExtended {
 }
 
 
-const stringType = {kind: Types.TypeKind.String, modifiers: [Types.ModifierFlags.None]}
+const stringType = {kind: Types.TypeKind.String, modifiers: Types.ModifierFlags.None}
 
 
 describe("interfaces", () => {
@@ -42,7 +42,7 @@ describe("interfaces", () => {
             [constKey]: stringType,
             ['computed-string']: stringType,
             [uniqSymb]: stringType,
-            method: {kind: Types.TypeKind.Function, modifiers: [Types.ModifierFlags.None]}
+            method: {kind: Types.TypeKind.Function, modifiers: Types.ModifierFlags.None}
         }
     });
   });

--- a/packages/tests/src/types/objectTypes.test.ts
+++ b/packages/tests/src/types/objectTypes.test.ts
@@ -6,7 +6,7 @@ const constKey = "some-key";
 const uniqSymb = Symbol("some symb");
 
 
-const stringType = {kind: Types.TypeKind.String}
+const stringType = {kind: Types.TypeKind.String, modifiers: [Types.ModifierFlags.None]}
 
 type ObjectType = {
     key: string

--- a/packages/tests/src/types/objectTypes.test.ts
+++ b/packages/tests/src/types/objectTypes.test.ts
@@ -6,7 +6,7 @@ const constKey = "some-key";
 const uniqSymb = Symbol("some symb");
 
 
-const stringType = {kind: Types.TypeKind.String, modifiers: [Types.ModifierFlags.None]}
+const stringType = {kind: Types.TypeKind.String, modifiers: Types.ModifierFlags.None}
 
 type ObjectType = {
     key: string

--- a/packages/tests/src/types/propertyInitializer.test.ts
+++ b/packages/tests/src/types/propertyInitializer.test.ts
@@ -40,17 +40,17 @@ function typeIsEqual(type: Types.ReflectedType, val: any) {
 
 describe("class properties initializers", () => {
   it("primitive types", () => {
-    typeIsEqual(getPropType("string"), { kind: TypeKind.String, modifiers: [Types.ModifierFlags.None] });
+    typeIsEqual(getPropType("string"), { kind: TypeKind.String, modifiers: Types.ModifierFlags.None });
     initializerIsEqual(getPropType("string"), 'string');
-    typeIsEqual(getPropType("number"), { kind: TypeKind.Number, modifiers: [Types.ModifierFlags.None]  });
+    typeIsEqual(getPropType("number"), { kind: TypeKind.Number, modifiers: Types.ModifierFlags.None  });
     initializerIsEqual(getPropType("number"), 42);
-    typeIsEqual(getPropType("true"), { kind: TypeKind.Boolean, modifiers: [Types.ModifierFlags.None]  });
+    typeIsEqual(getPropType("true"), { kind: TypeKind.Boolean, modifiers: Types.ModifierFlags.None  });
     initializerIsEqual(getPropType("true"), true);
-    typeIsEqual(getPropType("false"), { kind: TypeKind.Boolean, modifiers: [Types.ModifierFlags.None]  });
+    typeIsEqual(getPropType("false"), { kind: TypeKind.Boolean, modifiers: Types.ModifierFlags.None  });
     initializerIsEqual(getPropType("false"), false);
-    typeIsEqual(getPropType("null"), { kind: TypeKind.Null, modifiers: [Types.ModifierFlags.None]  });
+    typeIsEqual(getPropType("null"), { kind: TypeKind.Null, modifiers: Types.ModifierFlags.None  });
     initializerIsEqual(getPropType("null"), null);
-    typeIsEqual(getPropType("undefined"), { kind: TypeKind.Undefined, modifiers: [Types.ModifierFlags.None]  });
+    typeIsEqual(getPropType("undefined"), { kind: TypeKind.Undefined, modifiers: Types.ModifierFlags.None  });
     initializerIsEqual(getPropType("undefined"), undefined);
   });
   it("arrays", () => {
@@ -60,7 +60,7 @@ describe("class properties initializers", () => {
       typeIsEqual(type, {
         kind: TypeKind.Reference,
         type: Array,
-        modifiers: [Types.ModifierFlags.None],
+        modifiers: Types.ModifierFlags.None,
         arguments: [{ kind: TypeKind.String }]
       });
       initializerIsEqual(type, ["string"]);
@@ -72,7 +72,7 @@ describe("class properties initializers", () => {
     typeIsEqual(type, {
         kind: TypeKind.Reference,
         type: Cls,
-        modifiers: [Types.ModifierFlags.None],
+        modifiers: Types.ModifierFlags.None,
         arguments: []
       });
       expect(type.initializer).not.toBeUndefined()
@@ -84,7 +84,7 @@ describe("class properties initializers", () => {
     typeIsEqual(type, {
         kind: TypeKind.Reference,
         type: GenericCls,
-        modifiers: [Types.ModifierFlags.None],
+        modifiers: Types.ModifierFlags.None,
         arguments: [{ kind: Types.TypeKind.String }]
       });
       expect(type.initializer).not.toBeUndefined()

--- a/packages/tests/src/types/propertyInitializer.test.ts
+++ b/packages/tests/src/types/propertyInitializer.test.ts
@@ -40,17 +40,17 @@ function typeIsEqual(type: Types.ReflectedType, val: any) {
 
 describe("class properties initializers", () => {
   it("primitive types", () => {
-    typeIsEqual(getPropType("string"), { kind: TypeKind.String });
+    typeIsEqual(getPropType("string"), { kind: TypeKind.String, modifiers: [Types.ModifierFlags.None] });
     initializerIsEqual(getPropType("string"), 'string');
-    typeIsEqual(getPropType("number"), { kind: TypeKind.Number });
+    typeIsEqual(getPropType("number"), { kind: TypeKind.Number, modifiers: [Types.ModifierFlags.None]  });
     initializerIsEqual(getPropType("number"), 42);
-    typeIsEqual(getPropType("true"), { kind: TypeKind.Boolean });
+    typeIsEqual(getPropType("true"), { kind: TypeKind.Boolean, modifiers: [Types.ModifierFlags.None]  });
     initializerIsEqual(getPropType("true"), true);
-    typeIsEqual(getPropType("false"), { kind: TypeKind.Boolean });
+    typeIsEqual(getPropType("false"), { kind: TypeKind.Boolean, modifiers: [Types.ModifierFlags.None]  });
     initializerIsEqual(getPropType("false"), false);
-    typeIsEqual(getPropType("null"), { kind: TypeKind.Null });
+    typeIsEqual(getPropType("null"), { kind: TypeKind.Null, modifiers: [Types.ModifierFlags.None]  });
     initializerIsEqual(getPropType("null"), null);
-    typeIsEqual(getPropType("undefined"), { kind: TypeKind.Undefined });
+    typeIsEqual(getPropType("undefined"), { kind: TypeKind.Undefined, modifiers: [Types.ModifierFlags.None]  });
     initializerIsEqual(getPropType("undefined"), undefined);
   });
   it("arrays", () => {
@@ -60,6 +60,7 @@ describe("class properties initializers", () => {
       typeIsEqual(type, {
         kind: TypeKind.Reference,
         type: Array,
+        modifiers: [Types.ModifierFlags.None],
         arguments: [{ kind: TypeKind.String }]
       });
       initializerIsEqual(type, ["string"]);
@@ -71,6 +72,7 @@ describe("class properties initializers", () => {
     typeIsEqual(type, {
         kind: TypeKind.Reference,
         type: Cls,
+        modifiers: [Types.ModifierFlags.None],
         arguments: []
       });
       expect(type.initializer).not.toBeUndefined()
@@ -82,6 +84,7 @@ describe("class properties initializers", () => {
     typeIsEqual(type, {
         kind: TypeKind.Reference,
         type: GenericCls,
+        modifiers: [Types.ModifierFlags.None],
         arguments: [{ kind: Types.TypeKind.String }]
       });
       expect(type.initializer).not.toBeUndefined()

--- a/packages/tests/src/types/propertyModifiers.test.ts
+++ b/packages/tests/src/types/propertyModifiers.test.ts
@@ -1,4 +1,4 @@
-import {getClassType, Reflective, Types} from "tsruntime";
+import {getClassType, hasModifier, Reflective, Types} from "tsruntime";
 
 class Cls {
   f!: string;
@@ -25,19 +25,23 @@ abstract class SubCls extends Cls {
   }
 }
 
-function getPropModifier(name: string) {
+function getProperty(name: string) {
   const type = getClassType(SubCls);
-  return type.properties[name].modifiers;
+  return type.properties[name];
 }
 
 function matchModifiers(propName: string, expected: Types.ModifierFlags[]) {
-  expect({
-    name: propName,
-    modifiers: getPropModifier(propName)
-  }).toEqual({
-    name: propName,
-    modifiers: expected
-  });
+  for (const modifierFlag of expected) {
+    expect({
+      name: propName,
+      modifierFlag,
+      hasModifier: hasModifier(getProperty(propName) as any as {modifiers: number}, modifierFlag)
+    }).toEqual({
+      name: propName,
+      modifierFlag,
+      hasModifier: true
+    });
+  }
 }
 
 describe("class properties modifiers", () => {
@@ -46,10 +50,10 @@ describe("class properties modifiers", () => {
     matchModifiers("b", [Types.ModifierFlags.Public]);
     matchModifiers("c", [Types.ModifierFlags.Protected]);
     matchModifiers("d", [Types.ModifierFlags.Private]);
-    matchModifiers("e", [Types.ModifierFlags.None, Types.ModifierFlags.Readonly]);
-    matchModifiers("f", [Types.ModifierFlags.None, Types.ModifierFlags.Override]);
+    matchModifiers("e", [Types.ModifierFlags.Readonly]);
+    matchModifiers("f", [Types.ModifierFlags.Override]);
     matchModifiers("g", [Types.ModifierFlags.Protected, Types.ModifierFlags.Readonly, Types.ModifierFlags.Override]);
-    matchModifiers("h", [Types.ModifierFlags.None, Types.ModifierFlags.Abstract]);
+    matchModifiers("h", [Types.ModifierFlags.Abstract]);
     matchModifiers("i", [Types.ModifierFlags.Protected, Types.ModifierFlags.Abstract]);
     matchModifiers("j", [Types.ModifierFlags.Public, Types.ModifierFlags.Readonly]);
   });

--- a/packages/tests/src/types/propertyModifiers.test.ts
+++ b/packages/tests/src/types/propertyModifiers.test.ts
@@ -1,0 +1,56 @@
+import {getClassType, Reflective, Types} from "tsruntime";
+
+class Cls {
+  f!: string;
+  protected g!: string;
+  constructor() {
+  }
+}
+
+@Reflective
+abstract class SubCls extends Cls {
+  a!: string;
+  public b!: string;
+  protected c!: string;
+  private d!: string;
+  readonly e!: string;
+  override f!: string;
+  protected override readonly g!: string;
+  abstract h: string;
+  protected abstract i: string;
+  public readonly j!: string;
+
+  constructor() {
+    super();
+  }
+}
+
+function getPropModifier(name: string) {
+  const type = getClassType(SubCls);
+  return type.properties[name].modifiers;
+}
+
+function matchModifiers(propName: string, expected: Types.ModifierFlags[]) {
+  expect({
+    name: propName,
+    modifiers: getPropModifier(propName)
+  }).toEqual({
+    name: propName,
+    modifiers: expected
+  });
+}
+
+describe("class properties modifiers", () => {
+  it("matches modifiers", () => {
+    matchModifiers("a", [Types.ModifierFlags.None]);
+    matchModifiers("b", [Types.ModifierFlags.Public]);
+    matchModifiers("c", [Types.ModifierFlags.Protected]);
+    matchModifiers("d", [Types.ModifierFlags.Private]);
+    matchModifiers("e", [Types.ModifierFlags.None, Types.ModifierFlags.Readonly]);
+    matchModifiers("f", [Types.ModifierFlags.None, Types.ModifierFlags.Override]);
+    matchModifiers("g", [Types.ModifierFlags.Protected, Types.ModifierFlags.Readonly, Types.ModifierFlags.Override]);
+    matchModifiers("h", [Types.ModifierFlags.None, Types.ModifierFlags.Abstract]);
+    matchModifiers("i", [Types.ModifierFlags.Protected, Types.ModifierFlags.Abstract]);
+    matchModifiers("j", [Types.ModifierFlags.Public, Types.ModifierFlags.Readonly]);
+  });
+});

--- a/packages/tests/src/types/transform.test.ts
+++ b/packages/tests/src/types/transform.test.ts
@@ -39,7 +39,7 @@ describe("transform", () => {
         exported: {
           kind: Types.TypeKind.Reference,
           type: ExportedClass,
-          modifiers: [Types.ModifierFlags.None],
+          modifiers: Types.ModifierFlags.None,
           arguments: []
         }
       },
@@ -71,7 +71,7 @@ describe("transform", () => {
       name: "TestClass",
       kind: Types.TypeKind.Class,
       properties: {
-        prop: { kind: Types.TypeKind.String, modifiers: [Types.ModifierFlags.None] }
+        prop: { kind: Types.TypeKind.String, modifiers: Types.ModifierFlags.None }
       },
       constructors: [{modifiers: 0, parameters: []}],
     });

--- a/packages/tests/src/types/transform.test.ts
+++ b/packages/tests/src/types/transform.test.ts
@@ -39,6 +39,7 @@ describe("transform", () => {
         exported: {
           kind: Types.TypeKind.Reference,
           type: ExportedClass,
+          modifiers: [Types.ModifierFlags.None],
           arguments: []
         }
       },
@@ -70,7 +71,7 @@ describe("transform", () => {
       name: "TestClass",
       kind: Types.TypeKind.Class,
       properties: {
-        prop: { kind: Types.TypeKind.String }
+        prop: { kind: Types.TypeKind.String, modifiers: [Types.ModifierFlags.None] }
       },
       constructors: [{modifiers: 0, parameters: []}],
     });

--- a/packages/tsruntime/src/runtime/hasModifier.ts
+++ b/packages/tsruntime/src/runtime/hasModifier.ts
@@ -1,0 +1,8 @@
+import { ModifierFlags } from './publicTypes';
+
+export const hasModifier = (type: { modifiers: number }, modifier: ModifierFlags) => {
+  if (modifier === type.modifiers) {
+    return true;
+  }
+  return !!(type.modifiers & modifier);
+}

--- a/packages/tsruntime/src/runtime/index.ts
+++ b/packages/tsruntime/src/runtime/index.ts
@@ -1,6 +1,7 @@
 export * from './reflect'
 export * from './classUtils'
 export * from './common'
+export * from './hasModifier'
 
 import * as Types from './publicTypes';
 export {Types}

--- a/packages/tsruntime/src/runtime/publicTypes.ts
+++ b/packages/tsruntime/src/runtime/publicTypes.ts
@@ -1,6 +1,32 @@
-import { ModifierFlags } from "typescript";
-
-export { ModifierFlags } from "typescript";
+export enum ModifierFlags {
+  None = 0,
+  Export = 1,
+  Ambient = 2,
+  Public = 4,
+  Private = 8,
+  Protected = 16,
+  Static = 32,
+  Readonly = 64,
+  Accessor = 128,
+  Abstract = 256,
+  Async = 512,
+  Default = 1024,
+  Const = 2048,
+  HasComputedJSDocModifiers = 4096,
+  Deprecated = 8192,
+  Override = 16384,
+  In = 32768,
+  Out = 65536,
+  Decorator = 131072,
+  HasComputedFlags = 536870912,
+  AccessibilityModifier = 28,
+  ParameterPropertyModifier = 16476,
+  NonPublicAccessibilityModifier = 24,
+  TypeScriptModifier = 117086,
+  ExportDefault = 1025,
+  All = 258047,
+  Modifier = 126975
+}
 
 export enum TypeKind {
   Any = 1,

--- a/packages/tsruntime/src/runtime/publicTypes.ts
+++ b/packages/tsruntime/src/runtime/publicTypes.ts
@@ -1,3 +1,7 @@
+import { ModifierFlags } from "typescript";
+
+export { ModifierFlags } from "typescript";
+
 export enum TypeKind {
   Any = 1,
   String,
@@ -25,28 +29,6 @@ export enum TypeKind {
   Function,
 
   Unknown2 = 999
-}
-
-export enum ModifierFlags {
-  None = 0,
-  Export = 1,
-  Ambient = 2,
-  Public = 4,
-  Private = 8,
-  Protected = 16,
-  Static = 32,
-  Readonly = 64,
-  Abstract = 128,
-  Async = 256,
-  Default = 512,
-  Const = 2048,
-  HasComputedFlags = 536870912,
-  AccessibilityModifier = 28,
-  ParameterPropertyModifier = 92,
-  NonPublicAccessibilityModifier = 24,
-  TypeScriptModifier = 2270,
-  ExportDefault = 513,
-  All = 3071
 }
 
 export type StringType = BaseType<TypeKind.String, string>;
@@ -78,7 +60,7 @@ export type SimpleTypes =
   | UnknownType
   | Unknown2Type;
 
-  
+
 
 export type ReflectedType =
   | ObjectType
@@ -93,6 +75,7 @@ export type ReflectedType =
 
 export interface BaseType<TKind extends TypeKind, T> {
   kind: TKind;
+  modifiers?: ModifierFlags;
   initializer?: () => T;
 }
 

--- a/packages/tsruntime/src/transform/makeLiteral.ts
+++ b/packages/tsruntime/src/transform/makeLiteral.ts
@@ -15,7 +15,7 @@ function getExpressionForPropertyName(name: ts.PropertyName) { //copied from typ
 }
 
 
-export function makeLiteral(type: ReflectedType, modifiers?: ts.ModifierFlags): ts.ObjectLiteralExpression {
+export function makeLiteral(type: ReflectedType, modifier?: ts.ModifierFlags): ts.ObjectLiteralExpression {
     const assigns = []
     const kindAssign = ts.factory.createPropertyAssignment("kind", ts.factory.createNumericLiteral(type.kind))
     const kindAssignComment = ts.addSyntheticTrailingComment(kindAssign, ts.SyntaxKind.MultiLineCommentTrivia, TypeKind[type.kind], false)
@@ -25,11 +25,8 @@ export function makeLiteral(type: ReflectedType, modifiers?: ts.ModifierFlags): 
       assigns.push(ts.factory.createPropertyAssignment("initializer", type.initializer))
     }
 
-    if (typeof modifiers !== 'undefined') {
-      assigns.push(ts.factory.createPropertyAssignment(
-        "modifiers",
-        ts.factory.createNumericLiteral(modifiers)
-      ));
+    if (modifier !== undefined) {
+      assigns.push(ts.factory.createPropertyAssignment("modifiers", ts.factory.createNumericLiteral(modifier)));
     }
 
     switch (type.kind) {
@@ -57,10 +54,7 @@ export function makeLiteral(type: ReflectedType, modifiers?: ts.ModifierFlags): 
                 ts.factory.createPropertyAssignment("parameters", ts.factory.createArrayLiteralExpression(
                   parameters.map(({name, modifiers, type}) => ts.factory.createObjectLiteralExpression([
                     ts.factory.createPropertyAssignment("name", ts.factory.createStringLiteral(name)),
-                    ts.factory.createPropertyAssignment(
-                      "modifiers",
-                        ts.factory.createNumericLiteral(modifiers),
-                      ),
+                    ts.factory.createPropertyAssignment("modifiers", ts.factory.createNumericLiteral(modifiers)),
                     ts.factory.createPropertyAssignment("type", makeLiteral(type)),
                   ]))
                 ))

--- a/packages/tsruntime/src/transform/makeLiteral.ts
+++ b/packages/tsruntime/src/transform/makeLiteral.ts
@@ -7,44 +7,50 @@ function getExpressionForPropertyName(name: ts.PropertyName) { //copied from typ
     // if (ts.isComputedPropertyName(name)) {
     //   throw new Error('is computed property')
     // }
-  
+
     if (ts.isIdentifier(name)) {
-      return ts.createLiteral(ts.idText(name))
+      return ts.factory.createStringLiteral(ts.idText(name))
     }
     return name
 }
 
-  
+
 export function makeLiteral(type: ReflectedType): ts.ObjectLiteralExpression {
     const assigns = []
-    const kindAssign = ts.createPropertyAssignment("kind", ts.createLiteral(type.kind))
+    const kindAssign = ts.factory.createPropertyAssignment("kind", ts.factory.createNumericLiteral(type.kind))
     const kindAssignComment = ts.addSyntheticTrailingComment(kindAssign, ts.SyntaxKind.MultiLineCommentTrivia, TypeKind[type.kind], false)
     assigns.push(kindAssignComment)
     if (type.initializer !== undefined) {
-      assigns.push(ts.createPropertyAssignment("initializer", type.initializer))
+      assigns.push(ts.factory.createPropertyAssignment("initializer", type.initializer))
     }
 
     switch (type.kind) {
       case TypeKind.Object:
       case TypeKind.Class:
         if (type.name) {
-          assigns.push(ts.createPropertyAssignment("name", ts.createLiteral(type.name)))
+          assigns.push(ts.factory.createPropertyAssignment("name", ts.factory.createStringLiteral(type.name)))
         }
         // assigns.push(ts.createPropertyAssignment("arguments", ts.createArrayLiteral(type.arguments.map(makeLiteral))))
-        assigns.push(ts.createPropertyAssignment("properties", ts.createObjectLiteral(
-          type.properties.map(({name, type}) =>
-            ts.createPropertyAssignment(getExpressionForPropertyName(name), makeLiteral(type))
-        ))))
+        assigns.push(
+          ts.factory.createPropertyAssignment(
+            "properties",
+            ts.factory.createObjectLiteralExpression(
+              type.properties.map(({name, type}) =>
+                ts.factory.createPropertyAssignment(getExpressionForPropertyName(name), makeLiteral(type))
+              )
+            )
+          )
+        )
         if (type.kind === TypeKind.Class) {
-          assigns.push(ts.createPropertyAssignment("constructors", ts.createArrayLiteral(
+          assigns.push(ts.factory.createPropertyAssignment("constructors", ts.factory.createArrayLiteralExpression(
             (type).constructors.map(({modifiers, parameters}) =>
-              ts.createObjectLiteral([
-                ts.createPropertyAssignment("modifiers", ts.createLiteral(modifiers)),
-                ts.createPropertyAssignment("parameters", ts.createArrayLiteral(
-                  parameters.map(({name, modifiers, type}) => ts.createObjectLiteral([
-                    ts.createPropertyAssignment("name", ts.createLiteral(name)),
-                    ts.createPropertyAssignment("modifiers", ts.createLiteral(modifiers)),
-                    ts.createPropertyAssignment("type", makeLiteral(type)),
+              ts.factory.createObjectLiteralExpression([
+                ts.factory.createPropertyAssignment("modifiers", ts.factory.createNumericLiteral(modifiers)),
+                ts.factory.createPropertyAssignment("parameters", ts.factory.createArrayLiteralExpression(
+                  parameters.map(({name, modifiers, type}) => ts.factory.createObjectLiteralExpression([
+                    ts.factory.createPropertyAssignment("name", ts.factory.createStringLiteral(name)),
+                    ts.factory.createPropertyAssignment("modifiers", ts.factory.createNumericLiteral(modifiers)),
+                    ts.factory.createPropertyAssignment("type", makeLiteral(type)),
                   ]))
                 ))
               ])
@@ -54,26 +60,28 @@ export function makeLiteral(type: ReflectedType): ts.ObjectLiteralExpression {
         break
     }
     switch (type.kind) {
-      
+
       case TypeKind.Tuple:
-        assigns.push(ts.createPropertyAssignment("elementTypes", ts.createArrayLiteral(type.elementTypes.map(makeLiteral))))
+        assigns.push(ts.factory.createPropertyAssignment("elementTypes", ts.factory.createArrayLiteralExpression(type.elementTypes.map(makeLiteral))))
         break
       case TypeKind.Union:
-        assigns.push(ts.createPropertyAssignment("types", ts.createArrayLiteral(type.types.map(makeLiteral))))
+        assigns.push(ts.factory.createPropertyAssignment("types", ts.factory.createArrayLiteralExpression(type.types.map(makeLiteral))))
         break
       case TypeKind.StringLiteral:
+        assigns.push(ts.factory.createPropertyAssignment('value', ts.factory.createStringLiteral(type.value)))
+        break
       case TypeKind.NumberLiteral:
-        assigns.push(ts.createPropertyAssignment('value', ts.createLiteral(type.value)))
+        assigns.push(ts.factory.createPropertyAssignment('value', ts.factory.createNumericLiteral(type.value)))
         break
       case TypeKind.Reference:
-        assigns.push(ts.createPropertyAssignment("type", type.type))
-        assigns.push(ts.createPropertyAssignment("arguments", ts.createArrayLiteral(type.arguments.map(makeLiteral))))
+        assigns.push(ts.factory.createPropertyAssignment("type", type.type))
+        assigns.push(ts.factory.createPropertyAssignment("arguments", ts.factory.createArrayLiteralExpression(type.arguments.map(makeLiteral))))
         break
       case TypeKind.Class:
         if (type.extends !== undefined) {
-          assigns.push(ts.createPropertyAssignment("extends", makeLiteral(type.extends)))
+          assigns.push(ts.factory.createPropertyAssignment("extends", makeLiteral(type.extends)))
         }
         break
     }
-    return ts.createObjectLiteral(assigns)
+    return ts.factory.createObjectLiteralExpression(assigns)
 }

--- a/packages/tsruntime/src/transform/makeLiteral.ts
+++ b/packages/tsruntime/src/transform/makeLiteral.ts
@@ -15,7 +15,7 @@ function getExpressionForPropertyName(name: ts.PropertyName) { //copied from typ
 }
 
 
-export function makeLiteral(type: ReflectedType, modifiers?: ts.ModifierFlags[]): ts.ObjectLiteralExpression {
+export function makeLiteral(type: ReflectedType, modifiers?: ts.ModifierFlags): ts.ObjectLiteralExpression {
     const assigns = []
     const kindAssign = ts.factory.createPropertyAssignment("kind", ts.factory.createNumericLiteral(type.kind))
     const kindAssignComment = ts.addSyntheticTrailingComment(kindAssign, ts.SyntaxKind.MultiLineCommentTrivia, TypeKind[type.kind], false)
@@ -25,12 +25,10 @@ export function makeLiteral(type: ReflectedType, modifiers?: ts.ModifierFlags[])
       assigns.push(ts.factory.createPropertyAssignment("initializer", type.initializer))
     }
 
-    if (Array.isArray(modifiers)) {
+    if (typeof modifiers !== 'undefined') {
       assigns.push(ts.factory.createPropertyAssignment(
         "modifiers",
-        ts.factory.createArrayLiteralExpression(
-          modifiers.map(mod => ts.factory.createNumericLiteral(mod))
-        )
+        ts.factory.createNumericLiteral(modifiers)
       ));
     }
 
@@ -61,9 +59,7 @@ export function makeLiteral(type: ReflectedType, modifiers?: ts.ModifierFlags[])
                     ts.factory.createPropertyAssignment("name", ts.factory.createStringLiteral(name)),
                     ts.factory.createPropertyAssignment(
                       "modifiers",
-                        ts.factory.createArrayLiteralExpression(
-                          modifiers.map(mod => ts.factory.createNumericLiteral(mod))
-                        ),
+                        ts.factory.createNumericLiteral(modifiers),
                       ),
                     ts.factory.createPropertyAssignment("type", makeLiteral(type)),
                   ]))

--- a/packages/tsruntime/src/transform/reflect.ts
+++ b/packages/tsruntime/src/transform/reflect.ts
@@ -56,11 +56,6 @@ namespace Normalizers {
 }
 
 export function getReflect(ctx: Ctx) {
-  const accessModifiers = [
-    ts.ModifierFlags.Private,
-    ts.ModifierFlags.Protected,
-    ts.ModifierFlags.Public,
-  ];
   function serializeUnion(type: ts.UnionType): ReflectedType {
     const nestedTypes = type.types.map(t => reflectType(t));
     const normalizedTypes = Normalizers.normalizeUnion(nestedTypes);
@@ -147,15 +142,7 @@ export function getReflect(ctx: Ctx) {
     const decl = sym.declarations![0];
     const type = ctx.checker.getTypeOfSymbolAtLocation(sym, ctx.node);
     const serializedType = reflectType(type);
-    const modifiers = getModifiersFromDeclaration(decl, [
-      ts.ModifierFlags.Private,
-      ts.ModifierFlags.Protected,
-      ts.ModifierFlags.Public,
-      ts.ModifierFlags.Readonly,
-      ts.ModifierFlags.Override,
-      ts.ModifierFlags.Static,
-      ts.ModifierFlags.Abstract,
-    ]);
+    const modifiers = ts.getCombinedModifierFlags(decl);
 
     const name = getPropertyName(sym);
     const initializer = ts.isPropertyDeclaration(sym.valueDeclaration!)
@@ -172,13 +159,7 @@ export function getReflect(ctx: Ctx) {
   function serializeConstructorParameter(param: ts.Symbol): ConstructorParameter {
     const decl = param.declarations![0];
     const type = reflectType(ctx.checker.getTypeOfSymbolAtLocation(param, decl));
-    const modifiers = getModifiersFromDeclaration(decl, [
-      ts.ModifierFlags.Private,
-      ts.ModifierFlags.Protected,
-      ts.ModifierFlags.Public,
-      ts.ModifierFlags.Readonly,
-      ts.ModifierFlags.Override,
-    ]);
+    const modifiers = ts.getCombinedModifierFlags(decl);
 
     const initializer = param.valueDeclaration && ts.isParameter(param.valueDeclaration)
       ? serializeInitializer(param.valueDeclaration)
@@ -246,34 +227,6 @@ export function getReflect(ctx: Ctx) {
     // }
     // ctx.reportUnknownType(type);
     // return { kind: TypeKind.Unknown2 };
-  }
-
-  function getModifiersFromDeclaration(decl: ts.Declaration, includesModifiers: ts.ModifierFlags[] = []) {
-    const modifierFlags = ts.getCombinedModifierFlags(decl);
-    const modifiers = modifierFlags === 0
-      ? [ts.ModifierFlags.None]
-      : getModifiersByBruteForce(modifierFlags).filter(mod => includesModifiers.length === 0 || includesModifiers.includes(mod));
-
-    if (!modifiers.some(mod => accessModifiers.includes(mod)) && !modifiers.includes(ts.ModifierFlags.None)) {
-      modifiers.push(ts.ModifierFlags.None);
-    }
-    return modifiers.sort((a, b) => Number(a) - Number(b));
-  }
-
-  function getModifiersByBruteForce(modifierFlags: ts.ModifierFlags) {
-    const modifiers = [];
-    const modifiersToCheck = Object
-      .keys(ts.ModifierFlags)
-      .filter(k => isNaN(Number(k)))
-      .map(k => ts.ModifierFlags[k as keyof typeof ts.ModifierFlags]);
-
-    for (const mod of modifiersToCheck) {
-      if (modifierFlags & mod) {
-        modifiers.push(mod);
-      }
-    }
-
-    return modifiers;
   }
 
   function reflectType(type: ts.Type): ReflectedType {

--- a/packages/tsruntime/src/transform/reflect.ts
+++ b/packages/tsruntime/src/transform/reflect.ts
@@ -105,7 +105,7 @@ export function getReflect(ctx: Ctx) {
       default:
         name = type.getSymbol()!.getName();
     }
-    const typeIdentifier = ts.createIdentifier(name);
+    const typeIdentifier = ts.factory.createIdentifier(name);
     (typeIdentifier as any).flags &= ~ts.NodeFlags.Synthesized;
     (typeIdentifier as any).parent = ctx.currentScope;
     return typeIdentifier;
@@ -126,14 +126,14 @@ export function getReflect(ctx: Ctx) {
     if (nameSymb) {
       return nameSymb.valueDeclaration as any;
     } else {
-      //@ts-ignore
-      return ts.createLiteral(nameType.value);
+      //@ts-expect-error
+      return ts.factory.createLiteral(nameType.value);
     }
   }
 
   function serializeInitializer(decl: {initializer?: ts.Expression}): ts.ArrowFunction | undefined {
     return decl.initializer
-      ? ts.createArrowFunction(undefined, undefined, [], undefined, undefined, decl.initializer)
+      ? ts.factory.createArrowFunction(undefined, undefined, [], undefined, undefined, decl.initializer)
       : undefined;
   }
 

--- a/packages/tsruntime/src/transform/reflect.ts
+++ b/packages/tsruntime/src/transform/reflect.ts
@@ -57,9 +57,9 @@ namespace Normalizers {
 
 export function getReflect(ctx: Ctx) {
   const accessModifiers = [
-    Types.ModifierFlags.Private,
-    Types.ModifierFlags.Protected,
-    Types.ModifierFlags.Public,
+    ts.ModifierFlags.Private,
+    ts.ModifierFlags.Protected,
+    ts.ModifierFlags.Public,
   ];
   function serializeUnion(type: ts.UnionType): ReflectedType {
     const nestedTypes = type.types.map(t => reflectType(t));
@@ -148,12 +148,13 @@ export function getReflect(ctx: Ctx) {
     const type = ctx.checker.getTypeOfSymbolAtLocation(sym, ctx.node);
     const serializedType = reflectType(type);
     const modifiers = getModifiersFromDeclaration(decl, [
-      Types.ModifierFlags.Private,
-      Types.ModifierFlags.Protected,
-      Types.ModifierFlags.Public,
-      Types.ModifierFlags.Readonly,
-      Types.ModifierFlags.Static,
-      Types.ModifierFlags.Abstract,
+      ts.ModifierFlags.Private,
+      ts.ModifierFlags.Protected,
+      ts.ModifierFlags.Public,
+      ts.ModifierFlags.Readonly,
+      ts.ModifierFlags.Override,
+      ts.ModifierFlags.Static,
+      ts.ModifierFlags.Abstract,
     ]);
 
     const name = getPropertyName(sym);
@@ -172,10 +173,11 @@ export function getReflect(ctx: Ctx) {
     const decl = param.declarations![0];
     const type = reflectType(ctx.checker.getTypeOfSymbolAtLocation(param, decl));
     const modifiers = getModifiersFromDeclaration(decl, [
-      Types.ModifierFlags.Private,
-      Types.ModifierFlags.Protected,
-      Types.ModifierFlags.Public,
-      Types.ModifierFlags.Readonly,
+      ts.ModifierFlags.Private,
+      ts.ModifierFlags.Protected,
+      ts.ModifierFlags.Public,
+      ts.ModifierFlags.Readonly,
+      ts.ModifierFlags.Override,
     ]);
 
     const initializer = param.valueDeclaration && ts.isParameter(param.valueDeclaration)
@@ -246,14 +248,14 @@ export function getReflect(ctx: Ctx) {
     // return { kind: TypeKind.Unknown2 };
   }
 
-  function getModifiersFromDeclaration(decl: ts.Declaration, includesModifiers: Types.ModifierFlags[] = []) {
+  function getModifiersFromDeclaration(decl: ts.Declaration, includesModifiers: ts.ModifierFlags[] = []) {
     const modifierFlags = ts.getCombinedModifierFlags(decl);
     const modifiers = modifierFlags === 0
-      ? [Types.ModifierFlags.None]
+      ? [ts.ModifierFlags.None]
       : getModifiersByBruteForce(modifierFlags).filter(mod => includesModifiers.length === 0 || includesModifiers.includes(mod));
 
-    if (!modifiers.some(mod => accessModifiers.includes(mod)) && !modifiers.includes(Types.ModifierFlags.None)) {
-      modifiers.push(Types.ModifierFlags.None);
+    if (!modifiers.some(mod => accessModifiers.includes(mod)) && !modifiers.includes(ts.ModifierFlags.None)) {
+      modifiers.push(ts.ModifierFlags.None);
     }
     return modifiers.sort((a, b) => Number(a) - Number(b));
   }
@@ -261,9 +263,9 @@ export function getReflect(ctx: Ctx) {
   function getModifiersByBruteForce(modifierFlags: ts.ModifierFlags) {
     const modifiers = [];
     const modifiersToCheck = Object
-      .keys(Types.ModifierFlags)
+      .keys(ts.ModifierFlags)
       .filter(k => isNaN(Number(k)))
-      .map(k => Types.ModifierFlags[k as keyof typeof Types.ModifierFlags]);
+      .map(k => ts.ModifierFlags[k as keyof typeof ts.ModifierFlags]);
 
     for (const mod of modifiersToCheck) {
       if (modifierFlags & mod) {

--- a/packages/tsruntime/src/transform/transformer.ts
+++ b/packages/tsruntime/src/transform/transformer.ts
@@ -101,8 +101,8 @@ function Transformer(program: ts.Program, context: ts.TransformationContext) {
     const reflectedType = getReflect(ctx).reflectType(type);
     const literal = makeLiteral(reflectedType);
 
-    const newExpression = ts.createCall(node.expression, undefined, [literal])
-    return ts.updateCall(node, newExpression, node.typeArguments, ts.visitNodes(node.arguments, visitor))
+    const newExpression = ts.factory.createCallExpression(node.expression, undefined, [literal])
+    return ts.factory.updateCallExpression(node, newExpression, node.typeArguments, ts.visitNodes(node.arguments, visitor))
   }
 
   function visitDecotaror(node: ts.Decorator) {
@@ -113,7 +113,7 @@ function Transformer(program: ts.Program, context: ts.TransformationContext) {
     const ctx = createContext(node)
 
     const classDeclaration = node.parent
-    
+
     const type = checker.getTypeAtLocation(classDeclaration);
 
     if (classDeclaration.kind !== ts.SyntaxKind.ClassDeclaration) {
@@ -125,8 +125,8 @@ function Transformer(program: ts.Program, context: ts.TransformationContext) {
     >type);
     const literal = makeLiteral(reflectedType);
 
-    const newExpression = ts.createCall(node.expression, undefined, [literal]);
-    return ts.updateDecorator(node, newExpression);
+    const newExpression = ts.factory.createCallExpression(node.expression, undefined, [literal]);
+    return ts.factory.updateDecorator(node, newExpression);
   }
 
   function onBeforeVisitNode(node: ts.Node) {

--- a/packages/tsruntime/src/transform/types.ts
+++ b/packages/tsruntime/src/transform/types.ts
@@ -59,7 +59,7 @@ type Override2<T> = Override<T, {}>
 // type Override2<T, O> = T extends {[key: string]: infer R} ? {[key: string]: R extends Types.ReflectedType ? ReflectedType : R}: T
 
 
-type Properties = Array<{ name: ts.PropertyName; type: ReflectedType }>;
+type Properties = Array<{ name: ts.PropertyName; type: ReflectedType; modifiers: Types.ModifierFlags[] }>;
 export type ObjectType = Override<
   Types.ObjectType,
   {
@@ -90,7 +90,7 @@ export type ReferenceType = Override<
 
 export interface ConstructorParameter {
   name: string;
-  modifiers: ts.ModifierFlags;
+  modifiers: ts.ModifierFlags[];
   type: ReflectedType;
 }
 

--- a/packages/tsruntime/src/transform/types.ts
+++ b/packages/tsruntime/src/transform/types.ts
@@ -59,7 +59,7 @@ type Override2<T> = Override<T, {}>
 // type Override2<T, O> = T extends {[key: string]: infer R} ? {[key: string]: R extends Types.ReflectedType ? ReflectedType : R}: T
 
 
-type Properties = Array<{ name: ts.PropertyName; type: ReflectedType; modifiers: Types.ModifierFlags[] }>;
+type Properties = Array<{ name: ts.PropertyName; type: ReflectedType; modifiers: Types.ModifierFlags }>;
 export type ObjectType = Override<
   Types.ObjectType,
   {
@@ -90,7 +90,7 @@ export type ReferenceType = Override<
 
 export interface ConstructorParameter {
   name: string;
-  modifiers: ts.ModifierFlags[];
+  modifiers: ts.ModifierFlags;
   type: ReflectedType;
 }
 

--- a/packages/tsruntime/tsconfig.json
+++ b/packages/tsruntime/tsconfig.json
@@ -2,7 +2,8 @@
 {
     "extends": "../../tsconfig.json",
     "compilerOptions": {
-        "outDir": "dist",
+        "lib": ["dom", "es2016"],
+        "outDir": "dist"
     },
     "include": [
         "src/**/*"


### PR DESCRIPTION
## Purpose
Extract all modifiers from `ts.getCombinedModifierFlags`, which returns a combination of all modifier flags.

**Example**: If I have a `public readonly` property, the `ts.getCombinedModifierFlags` call returns 68, 4 (public) + 64 (readonly).

## Use case

I want expose the properties that have `None` or `Public` modifier to a Schema/DTO.